### PR TITLE
Cleaner, more reliable connector for Digitally Imported

### DIFF
--- a/connectors/difm-dom-inject.js
+++ b/connectors/difm-dom-inject.js
@@ -1,0 +1,23 @@
+/**
+ * Last.fm Scrobbler for Chrome - Digitally Imported connector
+ * @author Daniel Lo Nigro - http://dan.cx/
+ *
+ * This script runs in the context of di.fm itself. It listens for events fired
+ * by their JavaScript, and propagates these events to the extension via
+ * `postMessage`.
+ */
+
+(function() {
+  $(document).on('metadata-track', function(evt, metadata) {
+    window.postMessage({
+      type: 'DI_TRACK_CHANGE',
+      metadata: metadata
+    }, '*');
+  });
+
+  $(document).on('wp-stop', function(evt) {
+    window.postMessage({
+      type: 'DI_STOP'
+    }, '*');
+  });
+}());

--- a/connectors/difm.js
+++ b/connectors/difm.js
@@ -1,128 +1,64 @@
-var lastTrack;
+/**
+ * Last.fm Scrobbler for Chrome - Digitally Imported connector
+ * @author Daniel Lo Nigro - http://dan.cx/
+ *
+ * This script runs in the context of di.fm itself. It listens for events fired
+ * by their JavaScript, and propagates these events to the extension via
+ * `postMessage`.
+ */
 
-$(function() {
-  $('#now-playing .title-container').bind('DOMSubtreeModified', function() {
-    updateNowPlaying();
+(function() {
+  window.addEventListener('message', function(evt) {
+    switch (evt.data.type) {
+      case 'DI_TRACK_CHANGE':
+        updateNowPlaying(evt.data.metadata);
+        break;
+
+      case 'DI_STOP':
+        chrome.runtime.sendMessage({type: 'reset'});
+        break;
+    }
   });
 
   $(window).unload(function() {
     chrome.runtime.sendMessage({type: 'reset'});
     return true;
   });
-});
 
-
-/**
- * Find first occurence of possible separator in given string
- * and return separator's position and size in chars or null
- */
-function findSeparator(str) {
-  // care - minus vs hyphen
-  var separators = [' - ', ' – ', '-', '–', ':'];
-
-  for (i in separators) {
-    var sep = separators[i];
-    var index = str.indexOf(sep);
-    if (index > -1)
-      return { index: index, length: sep.length };
-  }
-
-  return null;
-}
-
-/**
- * Parse given string into artist and track, assume common order Art - Ttl
- * @return {artist, track}
- */
-function parseInfo(artistTitle) {
-  var separator = findSeparator(artistTitle);
-  if (separator == null)
-    return { artist: '', track: '' };
-
-  var artist = artistTitle.substr(0, separator.index);
-  var track = artistTitle.substr(separator.index + separator.length);
-
-  return cleanArtistTrack(artist, track);
-}
-
-
-/**
- * Clean non-informative garbage from title
- */
-function cleanArtistTrack(artist, track) {
-
-  // Do some cleanup
-  artist = artist.replace(/^\s+|\s+$/g,'');
-  track = track.replace(/^\s+|\s+$/g,'');
-
-  return {artist: artist, track: track};
-}
-
-
-function parseDurationString(timestr) {
-  if (timestr) {
-    var m = /((\d+):)?(\d+):(\d+)/.exec(timestr);
-    var duration = parseInt(m[3], 10) * 60 + parseInt(m[4], 10);
-    if (undefined != m[2]) {
-      duration += parseInt(m[3], 10) * 60 * 60;
-    }
-    return duration;
-  }
-  return 0;
-}
-
-function updateNowPlaying() {
-  var $nowPlaying = $("#now-playing");
-  var trackInfo = $nowPlaying.find(".title").text();
-  if ('' == trackInfo) return;
-
-  var elapsed = $nowPlaying.find(".timestamps .elapsed").text();
-  var remaining = $nowPlaying.find(".timestamps .remaining").text().substring(1);
-
-  var duration;
-  if (elapsed != '' && remaining != '') {
-    duration = parseDurationString(elapsed) + parseDurationString(remaining);
-  } else {
-    setTimeout(updateNowPlaying, 500); // Wait for timestamps to be loaded
-    return;
-  }
-
-  var parsedInfo = parseInfo(trackInfo);
-
-  var artist = parsedInfo['artist'];
-  var title = parsedInfo['track'];
-
-  if (lastTrack != artist + " " + title) {
-    lastTrack = artist + " " + title;
-
-    chrome.runtime.sendMessage({type: 'validate', artist: artist, track: title}, function(response) {
+  function updateNowPlaying(metadata) {
+    chrome.runtime.sendMessage({
+      type: 'validate',
+      artist: metadata.artist,
+      track: metadata.title
+    }, function(response) {
       if (response != false) {
         chrome.runtime.sendMessage({
           type: 'nowPlaying',
           artist: response.artist,
           track: response.track,
-          duration: duration
+          duration: metadata.duration
         });
       } else {
-        chrome.runtime.sendMessage({type: 'nowPlaying', duration: duration});
+        chrome.runtime.sendMessage({
+          type: 'nowPlaying',
+          duration: metadata.duration
+        });
       }
     });
   }
-}
 
+  /**
+   * Listen for requests from scrobbler.js
+   */
+  chrome.runtime.onMessage.addListener(
+    function(request, sender, sendResponse) {
+      switch(request.type) {
 
-/**
- * Listen for requests from scrobbler.js
- */
-chrome.runtime.onMessage.addListener(
-  function(request, sender, sendResponse) {
-    switch(request.type) {
-
-      // background calls this to see if the script is already injected
-      case 'ping':
-        sendResponse(true);
-        break;
+        // background calls this to see if the script is already injected
+        case 'ping':
+          sendResponse(true);
+          break;
+      }
     }
-  }
-);
-
+  );
+}());

--- a/connectors/jango.js
+++ b/connectors/jango.js
@@ -44,6 +44,7 @@ $(document).ready(function(){
   var comNode = $('<div id="chromeLastFM" style="display: none"><span id="title"></span><span id="artist"></span><span id="duration"></span></div>');
   document.body.appendChild(comNode[0]);
 
+  // TODO: Change this to use `jsInPageScope` in inject.js
   $('body').append('<script type="text/javascript">(function(l) {\n' +
 "    var injectScript = document.createElement('script');\n" +
 "    injectScript.type = 'text/javascript';\n" +

--- a/connectors/plugdj.js
+++ b/connectors/plugdj.js
@@ -89,6 +89,7 @@
         var comNode = $('<div id="chromeLastFM" style="display: none"></div>');
         document.body.appendChild(comNode[0]);
 
+        // TODO: Change this to use `jsInPageScope` in inject.js
         $('body').append('<script type="text/javascript">(function(l) {\n' +
             "    var injectScript = document.createElement('script');\n" +
             "    injectScript.type = 'text/javascript';\n" +

--- a/inject.js
+++ b/inject.js
@@ -489,7 +489,7 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
 function injectInPageScope(tabId, jsFile) {
     var injectScript =
         "var newScript = document.createElement('script');\n" +
-        "newScript.src = '" + chrome.extension.getURL(jsFile) + "';\n" +
+        "newScript.src = " + JSON.stringify(chrome.extension.getURL(jsFile)) + ";\n" +
         "document.head.appendChild(newScript)";
 
     chrome.tabs.executeScript(tabId, { code: injectScript });

--- a/inject.js
+++ b/inject.js
@@ -308,7 +308,8 @@ var connectors = [
     {
         label: "Digitally Imported",
         matches: ["*://www.di.fm/*"],
-        js: ["connectors/difm.js"]
+        js: ["connectors/difm.js"],
+        jsInPageScope: ["connectors/difm-dom-inject.js"],
     },
 
     {
@@ -451,6 +452,14 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
                         };
                         chrome.tabs.executeScript(tabId, injectDetails);
                     });
+
+                    // Inject any scripts that should run in the page's scope
+                    // rather than the extension sandbox
+                    if (connector.jsInPageScope) {
+                        connector.jsInPageScope.forEach(function (jsFile) {
+                            injectInPageScope(tabId, jsFile);
+                        });
+                    }
                 }
                 else {
                     console.log('-- subsequent ajax navigation, the scripts are already injected');
@@ -467,3 +476,21 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
         chrome.pageAction.hide(tabId);
     }
 });
+
+/**
+ * "Yo dawg, we heard you like scripts, so we put a script in a script."
+ * Injects a script to run in the scope of the page rather than in the context
+ * of this extension. To do so, we need to inject a <script> tag that loads
+ * a script.
+ *
+ * @param {number} tabID
+ * @param {string} jsFile
+ */
+function injectInPageScope(tabId, jsFile) {
+    var injectScript =
+        "var newScript = document.createElement('script');\n" +
+        "newScript.src = '" + chrome.extension.getURL(jsFile) + "';\n" +
+        "document.head.appendChild(newScript)";
+
+    chrome.tabs.executeScript(tabId, { code: injectScript });
+}

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
    "web_accessible_resources": [
       "icon128.png",
       "connectors/jango-dom-inject.js",
-      "connectors/plugdj-dom-inject.js"
+      "connectors/plugdj-dom-inject.js",
+      "connectors/difm-dom-inject.js"
    ],
 
    "background": {


### PR DESCRIPTION
Rather than listening to DOM mutations, this injects a script into the page's scope (via a similar method to what the Jango and PlugDJ connectors do) and listens directly to JavaScript events fired by their player.  Unlike the Jango and PlugDJ connectors which use a hacky method for communication (listening to DOM mutations on a hidden `div`), this one communicates to the extension via `window.postMessage` which is a lot cleaner. 

The script to inject the script is also cleaner and has been generalised in `inject.js` for easy reuse. The Jango and PlugDJ connectors could be updated to use this method at some point in the future. I've left todo comments in the code.

Open question: Is `window.postMessage` the cleanest way to do this? Should I be using an extension-specific API instead?  [This page](https://developer.chrome.com/extensions/messaging) documents `chrome.runtime.connect` but I can't seem to find this? `chrome.runtime` is null for me.

@pronskiy - What do you think?