### PR TITLE
Added support for bop.fm

### DIFF
--- a/connectors/v2/bopfm.js
+++ b/connectors/v2/bopfm.js
@@ -1,0 +1,10 @@
+
+Connector.playerSelector = '#bop-player';
+
+Connector.artistSelector = '#bop-player div.current-song-section > div.song-info > div.artist > a';
+
+Connector.trackSelector = '#bop-player div.current-song-section > div.song-info > div.title > a';
+
+Connector.isPlaying = function() {
+	return $('body').hasClass('song-playing');
+};

--- a/core/connectors.js
+++ b/core/connectors.js
@@ -457,6 +457,13 @@ define(function() {
 			label: 'Blitzr',
 			matches: ['*://*.blitzr.com/*', '*://blitzr.com/*'],
 			js: ['connectors/blitzr.js']
+		},
+
+		{
+			label: 'Bop.fm',
+			matches: ['*://bop.fm/*'],
+			js: ['connectors/v2/bopfm.js'],
+			version: 2
 		}
 	];
 });


### PR DESCRIPTION
Simple implementation that uses the V2 connector.

I noticed that the bop.fm site also has a really nice `Bop.Player` JavaScript object which we could bind too and listen to events and get further meta data from, such as duration.

refs #528 