### PR TITLE
Fix for SC

### DIFF
--- a/connectors/soundcloud-dom-inject.js
+++ b/connectors/soundcloud-dom-inject.js
@@ -12,10 +12,10 @@ window._ATTACHED = window._ATTACHED || false;
     // Exit if already attached.
     if (window._ATTACHED) return;
     // Attach event listeners to the event-bus.
-    webpackJsonp([1], 
-        { 
-          0: function(e, t, n) { 
-            bus = n(17);
+    webpackJsonp([1],
+        {
+          0: function(e, t, n) {
+            bus = n(16);
             bus.on('audio:play', function(e) {
                 window.postMessage({
                     type: 'SC_PLAY',


### PR DESCRIPTION
SC updated their code again and now the event bus is located @ index `16` again. Could be worth getting this validated by someone else before pulling this in though.