### PR TITLE
SC fix

### DIFF
--- a/connectors/soundcloud-dom-inject.js
+++ b/connectors/soundcloud-dom-inject.js
@@ -15,7 +15,7 @@ window._ATTACHED = window._ATTACHED || false;
     webpackJsonp([1],
         {
           0: function(e, t, n) {
-            bus = n(16);
+            bus = n(19);
             bus.on('audio:play', function(e) {
                 window.postMessage({
                     type: 'SC_PLAY',

--- a/connectors/soundcloud-dom-inject.js
+++ b/connectors/soundcloud-dom-inject.js
@@ -12,10 +12,25 @@ window._ATTACHED = window._ATTACHED || false;
     // Exit if already attached.
     if (window._ATTACHED) return;
     // Attach event listeners to the event-bus.
-    webpackJsonp([1],
-        {
-          0: function(e, t, n) {
+    webpackJsonp([1], {
+        0: function(e, t, n) {
+            function isEventBus(f) {
+                return typeof f === 'object' &&
+                    typeof f._events === 'object' &&
+                    typeof f._events.all !== 'undefined';
+            }
+
             bus = n(19);
+            if (!isEventBus(bus)) {
+                var i;
+                for (i = 0; i < 255; i++) {
+                    var test = n(i);
+                    if (isEventBus(test)) {
+                        bus = test;
+                        break;
+                    }
+                }
+            }
             bus.on('audio:play', function(e) {
                 window.postMessage({
                     type: 'SC_PLAY',
@@ -29,7 +44,6 @@ window._ATTACHED = window._ATTACHED || false;
                 }, '*');
             });
         }
-      }
-    );
+    });
     window._ATTACHED = true;
 }());


### PR DESCRIPTION
We need a more robust way as SC push code changes frequently which adjusts their packed resources.

Something like this would improve this:

```
			var i;
			for (i = 0; i < 255; i++) {
				var test = n(i);
				if (typeof test === 'object' && typeof test._events === 'object' && typeof test._events.all !== 'undefined') {
					break;
				}
			}

			bus = n(i);
```

Although it's only a basic test looking for the correct object but would provide more resilience. Opinions?
refs #546 