### PR TITLE
Fallback cover art via MusicBrainz/CoverArtArchive API

### DIFF
--- a/core/background/notifications.js
+++ b/core/background/notifications.js
@@ -87,7 +87,8 @@ define([
 						type: 'basic',
 						iconUrl: song.metadata.artistThumbUrl || 'icon128.png',
 						title: song.getTrack(),
-						message: 'by ' + song.getArtist()
+						message: 'by ' + song.getArtist(),
+						priority: 1
 					};
 
 					chrome.notifications.create('', options, notificationCreatedCb);

--- a/core/background/notifications.js
+++ b/core/background/notifications.js
@@ -56,20 +56,33 @@ define([
 
 				if(!song.metadata.artistThumbUrl) {
 					$.get("http://musicbrainz.org/ws/2/release?query="+song.getTrack()+" "+song.getArtist()+"&fmt=json&limit=1")
-					.done(function(musicbrainz) {
-						var MBID = musicbrainz.releases[0].id;
-						song.metadata.artistThumbUrl = "http://coverartarchive.org/release/"+MBID+"/front";
-						console.log("Found MUSICBRAINZ album artwork")
-						console.log(song.metadata.artistThumbUrl)
-						carryOn()
-					})
+						.done(function(musicbrainz) {
+							var MBID = musicbrainz.releases[0].id;
+							var coverArtURL = "http://coverartarchive.org/release/"+MBID+"/front";
+
+							$.ajax({url: coverArtURL, type:'HEAD' })
+								.done(function() {
+							        song.metadata.artistThumbUrl = coverArtURL
+							        console.log("Found MUSICBRAINZ album artwork")
+							    })
+							    .fail(function() {
+							        console.warn("Couldn't find any artwork :(")
+							    })
+							    .always(function() {
+							        carryOn()
+							    })
+						})
+						.fail(function() {
+					        console.log("Couldnae get MusicBrainz ID for song")
+							carryOn()
+						})
 				} else {
+					console.log("Got data on album artwork")
 					carryOn()
-					console.log("Found SPOTIFY album artwork")
-					console.log(song.metadata.artistThumbUrl)
 				}
 
 				function carryOn() {
+					console.log(song.metadata.artistThumbUrl)
 					var options = {
 						type: 'basic',
 						iconUrl: song.metadata.artistThumbUrl || 'icon128.png',

--- a/core/background/notifications.js
+++ b/core/background/notifications.js
@@ -54,14 +54,31 @@ define([
 		var createNotification = function(permissionLevel) {
 			if (permissionLevel === 'granted') {
 
-				var options = {
-					type: 'basic',
-					iconUrl: song.metadata.artistThumbUrl || 'icon128.png',
-					title: song.getTrack(),
-					message: 'by ' + song.getArtist()
-				};
+				if(!song.metadata.artistThumbUrl) {
+					$.get("http://musicbrainz.org/ws/2/release?query="+song.getTrack()+" "+song.getArtist()+"&fmt=json&limit=1")
+					.done(function(musicbrainz) {
+						var MBID = musicbrainz.releases[0].id;
+						song.metadata.artistThumbUrl = "http://coverartarchive.org/release/"+MBID+"/front";
+						console.log("Found MUSICBRAINZ album artwork")
+						console.log(song.metadata.artistThumbUrl)
+						carryOn()
+					})
+				} else {
+					carryOn()
+					console.log("Found SPOTIFY album artwork")
+					console.log(song.metadata.artistThumbUrl)
+				}
 
-				chrome.notifications.create('', options, notificationCreatedCb);
+				function carryOn() {
+					var options = {
+						type: 'basic',
+						iconUrl: song.metadata.artistThumbUrl || 'icon128.png',
+						title: song.getTrack(),
+						message: 'by ' + song.getArtist()
+					};
+
+					chrome.notifications.create('', options, notificationCreatedCb);
+				}
 			}
 		};
 

--- a/core/background/notifications.js
+++ b/core/background/notifications.js
@@ -53,47 +53,15 @@ define([
 
 		var createNotification = function(permissionLevel) {
 			if (permissionLevel === 'granted') {
+				var options = {
+					type: 'basic',
+					iconUrl: song.metadata.artistThumbUrl || 'icon128.png',
+					title: song.getTrack(),
+					message: 'by ' + song.getArtist()
+				};
 
-				if(!song.metadata.artistThumbUrl) {
-					$.get('http://musicbrainz.org/ws/2/release?query='+song.getTrack()+' '+song.getArtist()+'&fmt=json&limit=1')
-						.done(function(musicbrainz) {
-							var MBID = musicbrainz.releases[0].id;
-							var coverArtURL = 'http://coverartarchive.org/release/'+MBID+'/front';
-
-							$.ajax({url: coverArtURL, type:'HEAD' })
-								.done(function() {
-									song.metadata.artistThumbUrl = coverArtURL;
-									console.log('Found MUSICBRAINZ album artwork');
-								})
-								.fail(function() {
-									console.log('Couldn\'t find any artwork :(');
-								})
-								.always(function() {
-									carryOn();
-								});
-						})
-						.fail(function() {
-							console.log('Couldnae get MusicBrainz ID for song');
-							carryOn();
-						});
-				} else {
-					console.log('Got data on album artwork');
-					carryOn();
-				}
+				chrome.notifications.create('', options, notificationCreatedCb);
 			}
-		};
-
-		var carryOn = function() {
-			console.log(song.metadata.artistThumbUrl);
-			var options = {
-				type: 'basic',
-				iconUrl: song.metadata.artistThumbUrl || 'icon128.png',
-				title: song.getTrack(),
-				message: 'by ' + song.getArtist(),
-				priority: 1
-			};
-
-			chrome.notifications.create('', options, notificationCreatedCb);
 		};
 
 		chrome.notifications.getPermissionLevel(createNotification);

--- a/core/background/notifications.js
+++ b/core/background/notifications.js
@@ -55,45 +55,45 @@ define([
 			if (permissionLevel === 'granted') {
 
 				if(!song.metadata.artistThumbUrl) {
-					$.get("http://musicbrainz.org/ws/2/release?query="+song.getTrack()+" "+song.getArtist()+"&fmt=json&limit=1")
+					$.get('http://musicbrainz.org/ws/2/release?query='+song.getTrack()+' '+song.getArtist()+'&fmt=json&limit=1')
 						.done(function(musicbrainz) {
 							var MBID = musicbrainz.releases[0].id;
-							var coverArtURL = "http://coverartarchive.org/release/"+MBID+"/front";
+							var coverArtURL = 'http://coverartarchive.org/release/'+MBID+'/front';
 
 							$.ajax({url: coverArtURL, type:'HEAD' })
 								.done(function() {
-							        song.metadata.artistThumbUrl = coverArtURL
-							        console.log("Found MUSICBRAINZ album artwork")
-							    })
-							    .fail(function() {
-							        console.warn("Couldn't find any artwork :(")
-							    })
-							    .always(function() {
-							        carryOn()
-							    })
+									song.metadata.artistThumbUrl = coverArtURL;
+									console.log('Found MUSICBRAINZ album artwork');
+								})
+								.fail(function() {
+									console.log('Couldn\'t find any artwork :(');
+								})
+								.always(function() {
+									carryOn();
+								});
 						})
 						.fail(function() {
-					        console.log("Couldnae get MusicBrainz ID for song")
-							carryOn()
-						})
+							console.log('Couldnae get MusicBrainz ID for song');
+							carryOn();
+						});
 				} else {
-					console.log("Got data on album artwork")
-					carryOn()
-				}
-
-				function carryOn() {
-					console.log(song.metadata.artistThumbUrl)
-					var options = {
-						type: 'basic',
-						iconUrl: song.metadata.artistThumbUrl || 'icon128.png',
-						title: song.getTrack(),
-						message: 'by ' + song.getArtist(),
-						priority: 1
-					};
-
-					chrome.notifications.create('', options, notificationCreatedCb);
+					console.log('Got data on album artwork');
+					carryOn();
 				}
 			}
+		};
+
+		var carryOn = function() {
+			console.log(song.metadata.artistThumbUrl);
+			var options = {
+				type: 'basic',
+				iconUrl: song.metadata.artistThumbUrl || 'icon128.png',
+				title: song.getTrack(),
+				message: 'by ' + song.getArtist(),
+				priority: 1
+			};
+
+			chrome.notifications.create('', options, notificationCreatedCb);
 		};
 
 		chrome.notifications.getPermissionLevel(createNotification);

--- a/core/background/pipeline/musicbrainz-coverartarchive.js
+++ b/core/background/pipeline/musicbrainz-coverartarchive.js
@@ -1,0 +1,41 @@
+'use strict';
+
+define([], function() {
+
+	return {
+		/*  If song has no cover art:
+				1. try to identify it via the MusicBrainz API
+				2. use the song's MusicBrainz ID to query CoverArtArchive.org
+				3. check if the CoverArt is actually a useable HTTP resource
+		*/
+		getCoverArt: function (song, cb) {
+			if(!song.metadata.artistThumbUrl) {
+				$.get('http://musicbrainz.org/ws/2/release?query='+song.getTrack()+' '+song.getArtist()+'&fmt=json&limit=1')
+					.done(function(musicbrainz) {
+						var MBID = musicbrainz.releases[0].id;
+						var coverArtURL = 'http://coverartarchive.org/release/'+MBID+'/front';
+
+						$.ajax({url: coverArtURL, type:'HEAD' })
+							.done(function() {
+								song.metadata.artistThumbUrl = coverArtURL;
+								console.log('Found MUSICBRAINZ album artwork');
+							})
+							.fail(function() {
+								console.log('Couldn\'t find any artwork :(');
+							})
+							.always(function() {
+								cb();
+							});
+					})
+					.fail(function() {
+						console.log('Couldnae get MusicBrainz ID for song');
+						cb();
+					});
+			} else {
+				console.log('Found album artwork via LastFM');
+				cb();
+			}
+		}
+	};
+
+});

--- a/core/background/pipeline/musicbrainz-coverartarchive.js
+++ b/core/background/pipeline/musicbrainz-coverartarchive.js
@@ -2,6 +2,10 @@
 
 define([], function() {
 
+	// NB:
+	// Could potentially split `getMusicBrainzId()` and `getCoverArtArchive()` into consecutive pipeline modules,
+	// if we can come up with other uses for the MusicBrainz data.
+
 	var service = {
 		getCoverArt: function(song, cb) {
 			// Only query APIs if no cover art can be found
@@ -10,38 +14,61 @@ define([], function() {
 				cb();
 			} else {
 				console.log('Looking for album artwork via MusicBrainz');
-				// Try to ID the song via the MusicBrainz API
-				service.getMusicBrainzId(song, cb, function() {
-					// then Check for CoverArtArchive imagery against that MusicBrainz ID
-					service.getCoverArtArchive(song, cb);
-				});
+
+				// Search both, just incase there's artwork for the album, but not for the song/single
+				var endpoints = ['release','release-group'];
+
+				var coverArtSearch = function() {
+					if (endpoints.length < 1) {
+						return cb();
+					}
+
+					var endpoint = endpoints.shift();
+					// Try to ID the song via the MusicBrainz API
+					service.getMusicBrainzId(endpoint, song, coverArtSearch, function() {
+						// then Check for CoverArtArchive imagery against that MusicBrainz ID
+						service.getCoverArtArchive(song, coverArtSearch, cb);
+					});
+				};
+
+				coverArtSearch();
 			}
 		},
 
-		// NB:
-		// Could potentially split `getMusicBrainzId()` and `getCoverArtArchive()` into consecutive pipeline modules,
-		// if we can come up with other uses for the MusicBrainz data.
+		/* Get track or album MusicBrainz ID
+			* Search API docs:
+				http://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search
+			* Query syntax docs:
+				https://lucene.apache.org/core/4_3_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package_description
+		*/
+		getMusicBrainzId: function(endpoint, song, onFailure, onSuccess) {
+			$.get('http://musicbrainz.org/ws/2/' + endpoint + '?fmt=json&query=' +
+					'title:'+
+					'+"' + song.getTrack() + '"^3 ' + // bias towards the exact string
+					song.getTrack() + ' ' + // and individual words
 
-		getMusicBrainzId: function(song, onFailure, onSuccess) {
-			// Get MusicBrainz ID
-			// Search API docs: http://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search
-			$.get('http://musicbrainz.org/ws/2/release?query=' +
-				'title:' + song.getTrack() +
-				' AND ' +
-				'artist:' + song.getArtist() +
-				'&fmt=json&limit=1'
-			)
+					'artistname:'+
+					'+"' + song.getArtist() + '"^4' +
+					song.getArtist() + ' ' +
+				)
 				.done(function(musicbrainz) {
-					var MBID = musicbrainz.releases[0].id;
+					if (musicbrainz.count === 0) {
+						return onFailure();
+					}
+
+					var results = musicbrainz[endpoint + 's'];
+					var MBID = results[0].id;
 					song.metadata.musicBrainzId = MBID;
+
 					(typeof onSuccess === 'function' ? onSuccess : onFailure)(MBID);
 				})
 				.fail(onFailure);
 		},
 
+		// Requires song.metadata.musicBrainzId to have been previously retrieved
 		getCoverArtArchive: function(song, onFailure, onSuccess) {
-			// Look for CoverArtArchive.org images with this ID
 			var coverArtUrl = 'http://coverartarchive.org/release/' + song.metadata.musicBrainzId + '/front';
+
 			$.ajax({
 					url: coverArtUrl,
 					type: 'HEAD' // Check if the CoverArt is actually a useable HTTP resource; prevents Chrome errors
@@ -49,6 +76,7 @@ define([], function() {
 				.done(function() {
 					console.log('Found album artwork via MusicBrainz');
 					song.metadata.artistThumbUrl = coverArtUrl;
+
 					(typeof onSuccess === 'function' ? onSuccess : onFailure)(coverArtUrl);
 				})
 				.fail(onFailure);

--- a/core/background/pipeline/musicbrainz-coverartarchive.js
+++ b/core/background/pipeline/musicbrainz-coverartarchive.js
@@ -2,36 +2,58 @@
 
 define([], function() {
 
-	return {
-		/*  If song has no cover art:
-				1. try to identify it via the MusicBrainz API
-				2. use the song's MusicBrainz ID to query CoverArtArchive.org
-				3. check if the CoverArt is actually a useable HTTP resource
-		*/
-		getCoverArt: function (song, cb) {
-			if(song.metadata.artistThumbUrl) {
+	var service = {
+		getCoverArt: function(song, cb) {
+			// Only query APIs if no cover art can be found
+			if (song.metadata.artistThumbUrl) {
 				console.log('Found album artwork via LastFM');
 				cb();
 			} else {
-				// Get MusicBrainz ID
-				$.get('http://musicbrainz.org/ws/2/release?query='+song.getTrack()+' '+song.getArtist()+'&fmt=json&limit=1')
-					.done(function(musicbrainz) {
-						var MBID = musicbrainz.releases[0].id;
-						getCoverArtArchiveImg(MBID);
-					})
-					.fail(cb);
-
-				function getCoverArtArchiveImg(MBID) {
-					// Look for CoverArtArchive.org images with this ID
-					$.ajax({url: 'http://coverartarchive.org/release/'+MBID+'/front', type:'HEAD' })
-						.done(function() {
-							console.log('Found album artwork via MusicBrainz/CoverArtArchive');
-							song.metadata.artistThumbUrl = coverArtURL;
-						})
-						.always(cb);
-				}
+				console.log('Looking for album artwork via MusicBrainz');
+				// Try to ID the song via the MusicBrainz API
+				service.getMusicBrainzId(song, cb, function() {
+					// then Check for CoverArtArchive imagery against that MusicBrainz ID
+					service.getCoverArtArchive(song, cb);
+				});
 			}
+		},
+
+		// NB:
+		// Could potentially split `getMusicBrainzId()` and `getCoverArtArchive()` into consecutive pipeline modules,
+		// if we can come up with other uses for the MusicBrainz data.
+
+		getMusicBrainzId: function(song, onFailure, onSuccess) {
+			// Get MusicBrainz ID
+			// Search API docs: http://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search
+			$.get('http://musicbrainz.org/ws/2/release?query=' +
+				'title:' + song.getTrack() +
+				' AND ' +
+				'artist:' + song.getArtist() +
+				'&fmt=json&limit=1'
+			)
+				.done(function(musicbrainz) {
+					var MBID = musicbrainz.releases[0].id;
+					song.metadata.musicBrainzId = MBID;
+					(typeof onSuccess === 'function' ? onSuccess : onFailure)(MBID);
+				})
+				.fail(onFailure);
+		},
+
+		getCoverArtArchive: function(song, onFailure, onSuccess) {
+			// Look for CoverArtArchive.org images with this ID
+			var coverArtUrl = 'http://coverartarchive.org/release/' + song.metadata.musicBrainzId + '/front';
+			$.ajax({
+					url: coverArtUrl,
+					type: 'HEAD' // Check if the CoverArt is actually a useable HTTP resource; prevents Chrome errors
+				})
+				.done(function() {
+					console.log('Found album artwork via MusicBrainz');
+					song.metadata.artistThumbUrl = coverArtUrl;
+					(typeof onSuccess === 'function' ? onSuccess : onFailure)(coverArtUrl);
+				})
+				.fail(onFailure);
 		}
 	};
 
+	return service;
 });

--- a/core/background/pipeline/musicbrainz-coverartarchive.js
+++ b/core/background/pipeline/musicbrainz-coverartarchive.js
@@ -49,7 +49,7 @@ define([], function() {
 
 					'artistname:'+
 					'+"' + song.getArtist() + '"^4' +
-					song.getArtist() + ' ' +
+					song.getArtist() + ' '
 				)
 				.done(function(musicbrainz) {
 					if (musicbrainz.count === 0) {

--- a/core/background/pipeline/pipeline.js
+++ b/core/background/pipeline/pipeline.js
@@ -5,20 +5,22 @@
  */
 define([
 	'pipeline/user-input',
-	'pipeline/lfm-metadata'
-], function(UserInput, LfmMetadata) {
+	'pipeline/lfm-metadata',
+	'pipeline/musicbrainz-coverartarchive'
+], function(UserInput, LfmMetadata, MusicBrainz) {
 
 	return {
 		processSong: function(song) {
 			// list of processors is recreated for every processing call
 			var processors = [
 				UserInput.loadData, // loads data stored by user
-				LfmMetadata.loadSong // loads song metadata from L.FM and sets validation flag
+				LfmMetadata.loadSong, // loads song metadata from L.FM and sets validation flag
+				MusicBrainz.getCoverArt // looks for fallback cover art via API, in the even that it wasn't found earlier
 			];
 
 			var cb = function() {
 				if (processors.length > 0) {
-					var next =  processors.shift();
+					var next = processors.shift();
 					next(song, cb);
 				} else {
 					// processing finished, just set the flag

--- a/core/background/services/lastfm.js
+++ b/core/background/services/lastfm.js
@@ -268,37 +268,11 @@ define([
 				artistThumbUrl: $doc.find('album > image[size="medium"]').text()
 			});
 
-			// /*
-			// 	If cannot find artistThumbUrl, query MusicBrainz and CoverArtArchive for their data
-			// 	- http://musicbrainz.org/ws/2/release?query=Arctic%20Monkeys%20Do%20I%20Wanna%20Know&fmt=json&limit=1
-			// 	- coverartarchive.org/release/cab788d3-7e52-49d5-a4d8-7caaa1acbf48/front
+			song.flags.attr('isLastfmValid', true);
 
-			// 	// Query MusicBrainz for MBID
-			// 	// Get Album artwork from CoverArtArchive via MBID
-			// */
-			// if(!song.metadata.artistThumbUrl) {
-			// 	$.get("http://musicbrainz.org/ws/2/release?query="+song.getTrack()+" "+song.getArtist()+"&fmt=json&limit=1")
-			// 	.done(function(musicbrainz) {
-			// 		var MBID = musicbrainz.releases[0].id;
-			// 		song.metadata.artistThumbUrl = "http://coverartarchive.org/release/"+MBID+"/front";
-			// 		console.log("Found MUSICBRAINZ album artwork")
-			// 		console.log(song.metadata.artistThumbUrl)
-			// 		carryOn()
-			// 	})
-			// } else {
-			// 	carryOn()
-			// 	console.log("Found SPOTIFY album artwork")
-			// 	console.log(song.metadata.artistThumbUrl)
-			// }
+			can.batch.stop();
 
-			// function carryOn() {
-
-				song.flags.attr('isLastfmValid', true);
-
-				can.batch.stop();
-
-				cb(true);
-			// }
+			cb(true);
 		};
 
 		var errCb = function() {

--- a/core/background/services/lastfm.js
+++ b/core/background/services/lastfm.js
@@ -268,11 +268,37 @@ define([
 				artistThumbUrl: $doc.find('album > image[size="medium"]').text()
 			});
 
-			song.flags.attr('isLastfmValid', true);
+			// /*
+			// 	If cannot find artistThumbUrl, query MusicBrainz and CoverArtArchive for their data
+			// 	- http://musicbrainz.org/ws/2/release?query=Arctic%20Monkeys%20Do%20I%20Wanna%20Know&fmt=json&limit=1
+			// 	- coverartarchive.org/release/cab788d3-7e52-49d5-a4d8-7caaa1acbf48/front
 
-			can.batch.stop();
+			// 	// Query MusicBrainz for MBID
+			// 	// Get Album artwork from CoverArtArchive via MBID
+			// */
+			// if(!song.metadata.artistThumbUrl) {
+			// 	$.get("http://musicbrainz.org/ws/2/release?query="+song.getTrack()+" "+song.getArtist()+"&fmt=json&limit=1")
+			// 	.done(function(musicbrainz) {
+			// 		var MBID = musicbrainz.releases[0].id;
+			// 		song.metadata.artistThumbUrl = "http://coverartarchive.org/release/"+MBID+"/front";
+			// 		console.log("Found MUSICBRAINZ album artwork")
+			// 		console.log(song.metadata.artistThumbUrl)
+			// 		carryOn()
+			// 	})
+			// } else {
+			// 	carryOn()
+			// 	console.log("Found SPOTIFY album artwork")
+			// 	console.log(song.metadata.artistThumbUrl)
+			// }
 
-			cb(true);
+			// function carryOn() {
+
+				song.flags.attr('isLastfmValid', true);
+
+				can.batch.stop();
+
+				cb(true);
+			// }
 		};
 
 		var errCb = function() {


### PR DESCRIPTION
The code in this PR works for a fair number of (but not all) songs. I'm not sure that the file I've placed the logic in is the best place, but the mechanics of it work fine in practice.

I've only done this as I noticed the extension was no longer really ever getting imagery from Last.fm.