### PR TITLE
V2 Connectors track art + BC implementation

### DIFF
--- a/connectors/v2/bandcamp.js
+++ b/connectors/v2/bandcamp.js
@@ -83,6 +83,10 @@ Connector.playButtonSelector = 'div.playbutton:not(.playing)';
 
 Connector.currentTimeSelector = 'span.time_elapsed';
 
+Connector.getTrackArt = function() {
+	return $('#tralbumArt > a > img').attr('src') || $('#detail_gallery_container img').attr('src');
+};
+
 Connector.getDuration = function () {
 	return Math.round($('audio')[0].duration);
 };

--- a/core/background/objects/song.js
+++ b/core/background/objects/song.js
@@ -27,7 +27,8 @@ define([
 			uniqueID: parsedData.uniqueID || null,
 			duration: parsedData.duration || null,
 			currentTime: parsedData.currentTime || null,
-			isPlaying: parsedData.isPlaying || false
+			isPlaying: parsedData.isPlaying || false,
+			trackArt: parsedData.trackArt || false
 		};
 
 		/**
@@ -109,6 +110,14 @@ define([
 			var max = 4 * 60; // really long tracks are scrobbled after 4 minutes
 			var val = Math.max(this.getDuration() / 2, DEFAULT_SCROBBLE_TIME);
 			return Math.min(val, max); // whatever occurs first
+		};
+
+		/**
+		 * Return the track art associated with the song.
+		 * @return {String|null}
+		 */
+		song.getTrackArt = function() {
+			return this.parsed.trackArt || null;
 		};
 
 		return song;

--- a/core/background/services/lastfm.js
+++ b/core/background/services/lastfm.js
@@ -264,8 +264,13 @@ define([
 				duration: parseInt($doc.find('track > duration').text()) / 1000
 			});
 
+			var thumbUrl = song.getTrackArt();
+			if (thumbUrl === null) {
+				thumbUrl = $doc.find('album > image[size="medium"]').text();
+			}
+
 			song.metadata.attr({
-				artistThumbUrl: $doc.find('album > image[size="medium"]').text()
+				artistThumbUrl: thumbUrl
 			});
 
 			song.flags.attr('isLastfmValid', true);

--- a/core/content/connector.js
+++ b/core/content/connector.js
@@ -79,6 +79,15 @@ var BaseConnector = window.BaseConnector || function () {
 		 */
 		this.playerSelector = null;
 
+		/**
+		 * Selector of image used to represent the track being played. is used for
+		 * the notification service.
+		 *
+		 * If not specified will fall back to last.fm API.
+		 *
+		 * @type {string}
+		 */
+		this.trackArtImageSelector = null;
 
 		/**
 		 * Default implementation of artist name lookup by selector
@@ -195,6 +204,16 @@ var BaseConnector = window.BaseConnector || function () {
 			return this.playButtonSelector === null || !$(this.playButtonSelector).is(':visible');
 		};
 
+		/**
+		 * Default implementation used to get the track art from the trackArtImageSelector.
+		 *
+		 * Override this method for more complex behavor
+		 * @return {String|null}
+		 */
+		this.getTrackArt = function () {
+			return this.trackArtImageSelector === null ? null : $(this.trackArtImageSelector).attr('src');
+		};
+
 
 		// --- state & api -------------------------------------------------------------------------------------------------
 
@@ -276,6 +295,12 @@ var BaseConnector = window.BaseConnector || function () {
 			if (newIsPlaying !== currentState.isPlaying) {
 				currentState.isPlaying = newIsPlaying;
 				changedFields.push('isPlaying');
+			}
+
+			var newTrackArt = this.getTrackArt();
+			if (newTrackArt !== currentState.trackArt) {
+				currentState.trackArt = newTrackArt;
+				changedFields.push('trackArt');
 			}
 
 			// take action if needed


### PR DESCRIPTION
Added the ability for connectors to specify what image to display in the notification. 

Falls back to the current mechanisms if nothing specified.