### PR TITLE
Scrobble album title when using Google Play

### DIFF
--- a/connectors/v2/googlemusic.js
+++ b/connectors/v2/googlemusic.js
@@ -8,7 +8,7 @@ Connector.artistSelector = '#player-artist';
 
 Connector.trackSelector = '#player-song-title';
 
-Connector.albumSelector = '#player-album';
+Connector.albumSelector = '.player-album';
 
 Connector.currentTimeSelector = '#time_container_current';
 


### PR DESCRIPTION
There was a very small error in the new fix for Google Play. The new album selector tag is actually .player-album not #player-album (a class not an ID). I've tested this change out and now album titles are scrobbled as well as the artist and song title.