### PR TITLE
Prevent null artist/track being scrobbled

### DIFF
--- a/core/background/services/lastfm.js
+++ b/core/background/services/lastfm.js
@@ -246,6 +246,13 @@ define([
 	 * @param cb {Function(boolean)} callback where validation result will be passed
 	 */
 	function loadSongInfo(song, cb) {
+
+		if (song.processed.artist === null || song.prcoessed.track === null) {
+			song.flags.attr('isLastfmValid', false);
+			cb(false);
+			return;
+		}
+
 		var params = {
 			method: 'track.getinfo',
 			autocorrect: localStorage.useAutocorrect ? localStorage.useAutocorrect : 0,


### PR DESCRIPTION
I noticed that if the artist and or track was `null` this would still attempt to go through the whole processing pipeline. This check will prevent it from going through as apparently null - null is a valid song on last.fm.

Perhaps this is abusing the `isLastfmValid` but the checks are strict type. I'm open to suggestions of where such rejection should take place? Perhaps higher up in the controller?

refs: #628 