### PR TITLE
Fix SoundCloud injection

### DIFF
--- a/connectors/soundcloud-dom-inject.js
+++ b/connectors/soundcloud-dom-inject.js
@@ -29,9 +29,8 @@ window._ATTACHED = window._ATTACHED || false;
             if (!bus || !isEventBus(bus)) {
                 var i;
                 for (i = 0; i < 3491; i++) {
-                    var test;
                     try{
-                        test = n(i);
+                        var test = n(i);
                         if (isEventBus(test)) {
                             bus = test;
                             console.log("Event bus index changed to " + i + ". Please report at https://github.com/david-sabata/web-scrobbler/issues");

--- a/connectors/soundcloud-dom-inject.js
+++ b/connectors/soundcloud-dom-inject.js
@@ -20,17 +20,33 @@ window._ATTACHED = window._ATTACHED || false;
                     typeof f._events.all !== 'undefined';
             }
 
-            bus = n(19);
-            if (!isEventBus(bus)) {
+            var bus;
+            try{
+                bus = n(2459);
+            } catch (e) {
+            }
+
+            if (!bus || !isEventBus(bus)) {
                 var i;
-                for (i = 0; i < 255; i++) {
-                    var test = n(i);
-                    if (isEventBus(test)) {
-                        bus = test;
-                        break;
+                for (i = 0; i < 3491; i++) {
+                    var test;
+                    try{
+                        test = n(i);
+                        if (isEventBus(test)) {
+                            bus = test;
+                            console.log("Event bus index changed to " + i + ". Please report at https://github.com/david-sabata/web-scrobbler/issues");
+                            break;
+                        }
+                    } catch (e) {
                     }
                 }
             }
+
+            if (!bus) {
+                console.log("Cannot scrobble. Please report at https://github.com/david-sabata/web-scrobbler/issues");
+                return;
+            }
+            
             bus.on('audio:play', function(e) {
                 window.postMessage({
                     type: 'SC_PLAY',


### PR DESCRIPTION
Default index changed to 2459. Also increased search range to 0-3491, above nothing is defined.

Now calling n() with an invalid index throws a TypeError, catching those.

Added some logs, if the default index change again we need to be notified quickly as the loop to search a new index can take up to 288ms.