### PR TITLE
Add isStateChangeAllowed function, update slacker2 & mixcloud

### DIFF
--- a/connectors/v2/mixcloud.js
+++ b/connectors/v2/mixcloud.js
@@ -2,23 +2,7 @@
 
 /* global Connector */
 
-/* In lieu of playerSelector, custom detection of player state changes to allow loading and scrubbing to be ignored.
-     .player-handle:active occurs when user is scrubbing
-     .loading-state.spin classes are attached to play button during load
-*/
-var observer = new window.MutationObserver(function () {
-	if (!$('.player-handle:active')[0] && !$('.loading-state.spin')[0]) {
-		Connector.onStateChanged();
-	}
-});
-var observeTarget = document.querySelector('div.player-current-audio');
-var config = {
-	childList: true,
-	subtree: true,
-	attributes: true,
-	characterData: true
-};
-observer.observe(observeTarget, config);
+Connector.playerSelector = 'div.player-current-audio';
 
 Connector.artistSelector = '.current-artist .ng-binding';
 
@@ -26,4 +10,12 @@ Connector.trackSelector = '.current-track';
 
 Connector.isPlaying = function () {
 	return $('.player-control.pause-state').is(':visible');
+};
+
+/* Ignore changes while loading and scrubbing.
+ *	 .player-handle:active occurs when user is scrubbing
+ *	 .loading-state.spin classes are attached to play button during load
+*/
+Connector.isStateChangeAllowed = function () {
+	return (!$('.player-handle:active')[0] && !$('.loading-state.spin')[0]);
 };

--- a/connectors/v2/slacker2.js
+++ b/connectors/v2/slacker2.js
@@ -17,3 +17,13 @@ Connector.getDuration = function () {
 	return Connector.stringToSeconds($(Connector.currentTimeSelector).text() || '') +
 		Connector.stringToSeconds($('#progressContainer span:last').text() || '');
 };
+
+Connector.trackArtImageSelector = 'td.art img';
+
+/* At end of song, current time becomes "0:00" for a brief time before changing song info 
+ * which the controller treats as a rewind and a notification is displayed. 
+ * To overcome this, don't allow state change if current time is 0:00. 
+ */
+Connector.isStateChangeAllowed = function () {
+	return $(Connector.currentTimeSelector).text() !== '0:00';
+};

--- a/connectors/v2/slacker2.js
+++ b/connectors/v2/slacker2.js
@@ -20,9 +20,9 @@ Connector.getDuration = function () {
 
 Connector.trackArtImageSelector = 'td.art img';
 
-/* At end of song, current time becomes "0:00" for a brief time before changing song info 
- * which the controller treats as a rewind and a notification is displayed. 
- * To overcome this, don't allow state change if current time is 0:00. 
+/* At end of song, current time becomes "0:00" for a brief time before changing song info
+ * which the controller treats as a rewind and a notification is displayed.
+ * To overcome this, don't allow state change if current time is 0:00.
  */
 Connector.isStateChangeAllowed = function () {
 	return $(Connector.currentTimeSelector).text() !== '0:00';

--- a/core/content/connector.js
+++ b/core/content/connector.js
@@ -214,6 +214,16 @@ var BaseConnector = window.BaseConnector || function () {
 			return this.trackArtImageSelector === null ? null : $(this.trackArtImageSelector).attr('src');
 		};
 
+		/**
+		 * Default implementation of a check to see if a state change is allowed.
+		 *  MutationObserver will ignore mutations while this function returns false.
+		 *
+		 * Override this method to allow certain states to be ignored, for example if an advert is playing.
+		 * @return {Boolean}
+		 */
+		this.isStateChangeAllowed = function () {
+			return true;
+		};
 
 		// --- state & api -------------------------------------------------------------------------------------------------
 

--- a/core/content/starter.js
+++ b/core/content/starter.js
@@ -34,7 +34,11 @@
 	if (Connector.playerSelector !== null) {
 		console.log('Web Scrobbler: Setting up observer');
 
-		var observer = new MutationObserver(Connector.onStateChanged);
+		var observer = new window.MutationObserver(function () {
+			if (Connector.isStateChangeAllowed()) {
+				Connector.onStateChanged();
+			}
+		});
 
 		var observeTarget = document.querySelector(Connector.playerSelector);
 		var config = {


### PR DESCRIPTION
isStateChangeAllowed function allows the mutationObserver to ignore certain states, for example if an advert is playing.  Updated slacker2 & mixcloud connectors to include isStateChangeAllowed.  Added trackArtImageSelector to slacker2.