### PR TITLE
Fix for scrobbling issues - new last.fm

### DIFF
--- a/core/legacy/scrobbler.js
+++ b/core/legacy/scrobbler.js
@@ -313,7 +313,7 @@ define([
 			var http_request = new XMLHttpRequest();
 			http_request.open('POST', url, false); // synchronous
 			http_request.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-			http_request.send(params);
+			http_request.send();
 
 			console.log('nowPlaying request: %s', url);
 			console.log('nowPlaying response: %s', http_request.responseText);
@@ -396,7 +396,7 @@ define([
 			var http_request = new XMLHttpRequest();
 			http_request.open('POST', url, false); // synchronous
 			http_request.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-			http_request.send(params);
+			http_request.send();
 
 			if (http_request.status == 200) {
 				// Update page action icon


### PR DESCRIPTION
Changing http_request.send calls to not include body parameters, as these are breaking the signature checks in the Last.FM API.

Used a proxy to intercept the requests to Last.FM API and this is what I see:
```
POST /2.0/?method=track.scrobble&timestamp[0]=1440150650&track[0]=Ein%20Kompliment%20(Unplugged%20in%20New%20York)&artist[0]=Sportfreunde%20Stiller&api_key=d9bb1870d3269646f740544d9def2c95&sk=e8a91de8a56c4db7cdedc45444c4e9b6&source[0]=YouTube&sourceId[0]=VfD7Dc-qhuc&api_sig=e182e4e8f240663bd6ac7d4bf2ae4e78 HTTP/1.1
Host: ws.audioscrobbler.com
Connection: keep-alive
Content-Length: 15
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.155 Safari/537.36
Origin: chrome-extension://hhinaapppaileiechjoiifaancjggfjm
Content-type: application/x-www-form-urlencoded
Accept: */*
Accept-Encoding: gzip, deflate
Accept-Language: en-US,en;q=0.8,pl;q=0.6

[object Object]
```

The call works correctly after removing the body.