### PR TITLE
Allow popup submission using enter key

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -25,20 +25,22 @@
 	</head>
 	<body>
 		<div id="wrapper">
-			<table id="form">
-				<tr>
-					<th>Artist</th>
-					<td><input type="text" id="artist" tabindex="1" autofocus="autofocus"></td>
-				</tr>
-				<tr>
-					<th>Track</th>
-					<td><input type="text" id="track" tabindex="2"></td>
-				</tr>
-				<tr>
-					<th></th>
-					<td><input type="submit" id="submit" tabindex="3"></td>
-				</tr>
-			</table>
+			<form id="formwrapper">
+				<table id="form">
+					<tr>
+						<th>Artist</th>
+						<td><input type="text" id="artist" tabindex="1" autofocus="autofocus"></td>
+					</tr>
+					<tr>
+						<th>Track</th>
+						<td><input type="text" id="track" tabindex="2"></td>
+					</tr>
+					<tr>
+						<th></th>
+						<td><input type="submit" id="submit" tabindex="3"></td>
+					</tr>
+				</table>
+			</form>
 			<div id="valid">
 				<img src="icon_tick_big.png">
 			</div>

--- a/popup.js
+++ b/popup.js
@@ -41,9 +41,9 @@ $(function() {
 		$('#artist').val(song.processed.artist || song.parsed.artist);
 		$('#track').val(song.processed.track || song.parsed.track);
 
-		$('#submit').click(function () {
-			$(this).attr('disabled', true);
-			$(this).siblings().remove();
+		var submissionHandler = function() {
+			$('#submit').attr('disabled', true);
+			$('#submit').siblings().remove();
 
 			var data = {
 				artist: $('#artist').val(),
@@ -59,7 +59,16 @@ $(function() {
 			// show green tick even if the song may not be valid - we have no way of knowing yet
 			$('#form').fadeOut(0);
 			$('#valid').fadeIn(0);
+		};
+
+		// submission works for both click and enter key (using form wrapper)
+		$('#submit').click(function() {
+			submissionHandler();
 		});
+		$('#formwrapper').submit(function() {
+			submissionHandler();
+		});
+
 	}
 
 
@@ -78,9 +87,10 @@ $(function() {
 			$('#track').val(song.track);
 		}
 
-		$('#submit').click(function () {
-			$(this).attr('disabled', true);
-			$(this).siblings().remove();
+		var submissionHandler = function() {
+			console.log('handling legacy');
+			$('#submit').attr('disabled', true);
+			$('#submit').siblings().remove();
 
 			var artist = $('#artist').val();
 			var track = $('#track').val();
@@ -118,7 +128,15 @@ $(function() {
 			};
 
 			popupApi.validate(artist, track, validateCB);
+		};
+
+		$('#submit').click(function() {
+			submissionHandler();
 		});
+		$('#formwrapper').submit(function() {
+			submissionHandler();
+		});
+
 	}
 
 


### PR DESCRIPTION
I see that #74 was fixed a while back, but I've been unable to use the enter key to submit the popup, so I added an HTML form element (with ID `formwrapper`) around the table, which allows the submit button to work properly. I also named the callback function for `$('#submit').click()` in order to have it handle `$('#formwrapper').submit()` as well.