### PR TITLE
Add album recognizing to connectors, fix #576

### DIFF
--- a/connectors/v2/farfrommoscow.js
+++ b/connectors/v2/farfrommoscow.js
@@ -9,20 +9,20 @@ Connector.isPlaying = function () {
 			$('.Artist-Mini-Playing').length ||
 			$('.Artist-Maximus-Playing').length ||
 			$('.Hello-Mini-Playing').length ||
-			($('#PlayerFrame iframe').contents().find("#Play").length ? //embed
-			$('#PlayerFrame iframe').contents().find("#Play").attr('src').indexOf('pause') !== -1 :
-			false);
+			($('#PlayerFrame iframe').contents().find('#Play').length ? //embed
+					$('#PlayerFrame iframe').contents().find('#Play').attr('src').indexOf('pause') !== -1 :
+					false);
 };
 
 Connector.getArtistTrack = function () {
 	var artist = null;
 	var track = null;
 
-	if ($('#PlayerFrame iframe').contents().find("#Play").length ? //embed
-			$('#PlayerFrame iframe').contents().find("#Play").attr('src').indexOf('pause') !== -1 :
+	if ($('#PlayerFrame iframe').contents().find('#Play').length ? //embed
+			$('#PlayerFrame iframe').contents().find('#Play').attr('src').indexOf('pause') !== -1 :
 			false) { //embed
 		artist = $('.H-artist').text();
-		track = $('#PlayerFrame iframe').contents().find("#PlayerPanel > :first-child").text();
+		track = $('#PlayerFrame iframe').contents().find('#PlayerPanel > :first-child').text();
 	} else if ($('.player-buttonPause').length) {
 		var text = $('.player:has(.player-buttonPause) .player-name span').text();
 		var separator = this.findSeparator(text);
@@ -46,7 +46,7 @@ Connector.getArtistTrack = function () {
 	return {artist: artist, track: track};
 };
 Connector.getAlbum = function () {
-	return $('#PlayerFrame iframe').contents().find("#Play").length ? //embed
+	return $('#PlayerFrame iframe').contents().find('#Play').length ? //embed
 			$('#TrackList h1').text() :
 			$('.Release-preview:has(.Hello-Mini-Playing) .Release-select strong').text() || null;
 };

--- a/connectors/v2/farfrommoscow.js
+++ b/connectors/v2/farfrommoscow.js
@@ -5,24 +5,48 @@
 Connector.playerSelector = '.global-content';
 
 Connector.isPlaying = function () {
-	return $('.player-buttonPause').length ? true : $('.Artist-Mini-Playing').length;
+	return $('.player-buttonPause').length ||
+			$('.Artist-Mini-Playing').length ||
+			$('.Artist-Maximus-Playing').length ||
+			$('.Hello-Mini-Playing').length ||
+			($('#PlayerFrame iframe').contents().find("#Play").length ? //embed
+			$('#PlayerFrame iframe').contents().find("#Play").attr('src').indexOf('pause') !== -1 :
+			false);
 };
 
 Connector.getArtistTrack = function () {
-	var artist = $('.AR-wrap:has(.Artist-Mini-Playing) .AR-name').length ? $('.AR-wrap:has(.Artist-Mini-Playing) .AR-name').text() : $(':has(.Artist-Mini-Playing) > div > .Artist-link').text();
-	var track = $('.Artist-Mini-Playing').attr('title');
-	if (artist.length) {return {artist: artist, track: track};}
+	var artist = null;
+	var track = null;
 
-	var text = $('.player:has(.player-buttonPause) .player-name span').text();
-	var separator = this.findSeparator(text);
+	if ($('#PlayerFrame iframe').contents().find("#Play").length ? //embed
+			$('#PlayerFrame iframe').contents().find("#Play").attr('src').indexOf('pause') !== -1 :
+			false) { //embed
+		artist = $('.H-artist').text();
+		track = $('#PlayerFrame iframe').contents().find("#PlayerPanel > :first-child").text();
+	} else if ($('.player-buttonPause').length) {
+		var text = $('.player:has(.player-buttonPause) .player-name span').text();
+		var separator = this.findSeparator(text);
 
-	artist = null;
-	track = null;
+		if (separator !== null) {
+			artist = text.substr(0, separator.index).trim();
+			track = text.substr(separator.index + separator.length).trim();
+		}
+	} else if ($('.Hello-Mini-Playing').length) {
+		artist = $('.H-artist').text();
+		track = $('.Hello-Mini-Playing').attr('title');
+	} else {
+		artist = $('.AR-wrap:has(.Artist-Mini-Playing) .AR-name').text() ||
+				$(':has(.Artist-Mini-Playing) > div > .Artist-link').text() ||
+				$('.A-wrap:has(.Artist-Maximus-Playing) .AR-name').text();
 
-	if (separator !== null) {
-		artist = text.substr(0, separator.index).trim();
-		track = text.substr(separator.index + separator.length).trim();
+		track = $('.Artist-Mini-Playing').attr('title') ||
+				$('.Artist-Maximus-Playing').attr('title');
 	}
 
 	return {artist: artist, track: track};
+};
+Connector.getAlbum = function () {
+	return $('#PlayerFrame iframe').contents().find("#Play").length ? //embed
+			$('#TrackList h1').text() :
+			$('.Release-preview:has(.Hello-Mini-Playing) .Release-select strong').text() || null;
 };


### PR DESCRIPTION
#576

- [x] farfrommoscow
- [x] musicload

Xbox Music (now Groove Music) rebranded June 6th, 2015. Looks like it also redesigned, now it not show album in player, even in code.
Spotify not show album in player, even in code.

Other services not support albums (because use youtube/soundcloud)/not shown album in player, or its connectors already recognize albums.