### PR TITLE
Fix Bandcamp various artist scrobbling

### DIFF
--- a/connectors/v2/bandcamp.js
+++ b/connectors/v2/bandcamp.js
@@ -62,8 +62,8 @@ Connector.getArtistTrack = function () {
 		separatorIndex;
 	if (artistIsVarious()) {
 		separatorIndex = Math.max(track.indexOf('-'), track.indexOf('|'));
-		artist = track.substring(0, separatorIndex);
-		track = track.substring(separatorIndex + 1);
+		artist = cleanText(track.substring(0, separatorIndex));
+		track = cleanText(track.substring(separatorIndex + 1));
 	}
 	return {
 		artist: artist,


### PR DESCRIPTION
The Last.fm API no longer trims artist and track names, so ensure
they're always trimmed in the Bandcamp connector.