### PR TITLE
Add cache artist track

### DIFF
--- a/core/background/controller.js
+++ b/core/background/controller.js
@@ -205,7 +205,22 @@ define([
 					pageAction.setSiteSupported();
 				}
 			} else {
-				pageAction.setSongNotRecognized();
+				// try to load a processed artist track from local storage
+				var key = song.parsed.uniqueID;
+				chrome.storage.local.get(key, function(data) {
+					var processed = data[key];
+					if (processed) {
+						// setUserSongData(processed);
+						// alert("doesn't reach here");
+
+						// temp fix
+						song.processed = processed;
+						song.flags.attr('isCorrectedByUser', true);
+						onProcessed(song);
+					} else {
+						pageAction.setSongNotRecognized();
+					}
+				});
 			}
 		}
 

--- a/core/background/pipeline/user-input.js
+++ b/core/background/pipeline/user-input.js
@@ -19,6 +19,11 @@ define([], function() {
 
 			if (changed) {
 				song.flags.attr('isCorrectedByUser', true);
+
+				// save the processed artist track to local storage
+				var cache = {};
+				cache[song.parsed.attr('uniqueID')] = song.processed;
+				chrome.storage.local.set(cache);
 			}
 
 			cb();


### PR DESCRIPTION
Use case:
Whenever the artist and track cannot be parsed, we can fix that by scrobbling manually. However, that cleaned artist and track is lost when we re-visit the page. This fixes the problem by saving user input for the song on chrome's local storage, and then loading it when the same song is re-visited later.

Technical issue:
After loading from the local storage, I wanted to make it seem as though it was a manual scrobble by calling setUserSongData. However, it does not seem to be working and I appreciate any inputs on getting it to work.

Right now, as a temporary fix, I'm just calling onProcessed directly. It works, but the notification, now playing, and album art won't be updated.
