### PR TITLE
Update Plex activation URL

### DIFF
--- a/core/connectors.js
+++ b/core/connectors.js
@@ -384,7 +384,7 @@ define(function() {
 
 		{
 			label: 'PLEX',
-			matches: ['*://*32400/web/*', '*://plex.tv/web/*'],
+			matches: ['*://*32400/web/*', '*://*.plex.tv/web/*'],
 			js: ['connectors/plex.js']
 		},
 


### PR DESCRIPTION
Put wildcard in front of `plex.tv` due to newer URLs being `app.plex.tv`

Closes #839 