### PR TITLE
Ego.fm connector -

### DIFF
--- a/connectors/v2/ego-fm.js
+++ b/connectors/v2/ego-fm.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/* global Connector */
+
+Connector.playerSelector = '#playerInfo';
+
+Connector.artistSelector = '#current > span.artist';
+
+Connector.trackSelector = '#current > span.song';
+
+Connector.isPlaying = function () {
+	var spanelement = document.querySelector('.now');
+	if(spanelement !== null)
+	{
+		if( spanelement.innerHTML == 'Jetzt:')
+		{
+			return true;
+		}
+	}
+	else
+	{
+		return false;
+	}
+};

--- a/core/connectors.js
+++ b/core/connectors.js
@@ -860,6 +860,12 @@ define(function() {
 			js: ['connectors/v2/dreamfm.js'],
 			version: 2
 		},
+		{
+			label: 'Ego FM',
+			matches: ['*://www.egofm.de/*'],
+			js: ['connectors/v2/ego-fm.js'],
+			version: 2
+		},
 
 		{
 			label: 'Radio Paradise',


### PR DESCRIPTION
Warning: as the player runs on a different domain and the playing information is displayed reliably (and with ajax update) only on www.egofm.de, this version scrobbles when the homepage is open, regardless of the status of the external player. For me it's kind of a feature, because sometimes I listen to this radio on plain old FM :)

If this is not acceptable, please reject this PR and advise on how to read the content of an iframe running a different domain (prevented by anti XSS measures in the browser)