### PR TITLE
Notify of authentication problems

### DIFF
--- a/core/background/services/lastfm.js
+++ b/core/background/services/lastfm.js
@@ -143,6 +143,7 @@ define([
 			})
 			.fail(function(jqxhr, textStatus, error) {
 				console.error('auth.getSession failed: ' + error + ', ' + textStatus);
+				cb(null);
 			});
 	}
 


### PR DESCRIPTION
`tradeTokenForSession` function callback wasn't called on token request error, and user wasn't noticed of authentication errors on startup. The notification was shown only one time after extenstion installation.

It fixes notifications supposed to be shown at extension startup. But if something goes wrong with authentication while using extension, user won't be noticed about that. It's possible to implement notification on 'now playing' and 'scrobble' auth errors, but I can't find a proper way to notify user. I have 2 options:
1. Show same notifications as ones are shown at startup. It might be annoying (so we can show one notification per user session).
2. Show an auth error icon in omnibar. It's good to attract user attention, but it's need to implement navigation to LastFM auth page by clicking on the icon. I have no idea how to do that.