### PR TITLE
Lookup for Youtube song metadata only if it's neccessary

### DIFF
--- a/connectors/v2/youtube.js
+++ b/connectors/v2/youtube.js
@@ -54,11 +54,12 @@ Connector.getUniqueID = function() {
 };
 
 Connector.isPlaying = function() {
-	return (
-		/* Can scrobble from any genre */ !scrobbleMusicOnly ||
-		/* OR only music AND is music  */ ( scrobbleMusicOnly && $('meta[itemprop=\"genre\"]').attr('content') == 'Music' )
-	)	? $('#player-api .html5-video-player').hasClass('playing-mode')
-		: false;
+	return $('#player-api .html5-video-player').hasClass('playing-mode');
+};
+
+Connector.isStateChangeAllowed = function() {
+	var videoCategory = $('meta[itemprop=\"genre\"]').attr('content');
+	return !scrobbleMusicOnly || (scrobbleMusicOnly && videoCategory == 'Music');
 };
 
 Connector.getArtistTrack = function () {


### PR DESCRIPTION
There's no reason to start metadata lookup for songs not supposed to be scrobbled, e.g. Youtube music videos in non-music category (of course with enabled option is preferences). Also it might be confusing.