### PR TITLE
Fix non-proper work of Yandex radio connector

### DIFF
--- a/connectors/v2/yandexradio.js
+++ b/connectors/v2/yandexradio.js
@@ -2,10 +2,40 @@
 
 /* global Connector */
 
-Connector.playerSelector = '.page-station__bar';
 Connector.trackArtImageSelector = '.slider__items > div:nth-child(3) .track__cover';
 Connector.trackSelector = '.slider__items > div:nth-child(3) .track__title';
 Connector.artistSelector = '.slider__items > div:nth-child(3) .track__artists';
+
 Connector.isPlaying = function() {
 	return $('body').hasClass('body_state_playing');
 };
+
+(function() {
+	var actualObserver;
+	var playerObserver = new MutationObserver(function() {
+		var playerSelector = document.querySelector('.page-station__bar');
+		if (playerSelector !== null) {
+			if (!actualObserver) {
+				actualObserver = new MutationObserver(Connector.onStateChanged);
+				actualObserver.observe(playerSelector, {
+					subtree: true,
+					childList: true,
+					attributes: true,
+					characterData: true
+				});
+			}
+		} else {
+			if (actualObserver) {
+				actualObserver.disconnect();
+				actualObserver = null;
+			}
+		}
+	});
+
+	playerObserver.observe(document.body, {
+		subtree: true,
+		childList: true,
+		attributes: false,
+		characterData: false
+	});
+})();


### PR DESCRIPTION
The problem is that scrobbling doesn't work if user selects radio station from station page.
If user opens radio station directly from station url, scrobbling works well. And scrobbling stops working if user begins to browse pages on Yandex radio.

The solution is creating two MutationObservers. The first one observes appearing of player controls element; if the element is present in DOM, the second observer starts working. It works directly with song changes.