### PR TITLE
Handle trackart update

### DIFF
--- a/core/background/controller.js
+++ b/core/background/controller.js
@@ -84,7 +84,8 @@ define([
 
 				currentSong.parsed.attr({
 					currentTime: newState.currentTime,
-					isPlaying: newState.isPlaying
+					isPlaying: newState.isPlaying,
+					trackArt: newState.trackArt,
 				});
 			}
 			// we've hit a new song (or replaying the previous one) - clear old data and run processing

--- a/popups/popup.css
+++ b/popups/popup.css
@@ -23,7 +23,7 @@ a {
 	width: 100px;
 	height: 100px;
 	float: left;
-	background-image: url('img/default_artist_large.png');
+	background-image: url('../default_cover_art.png');
 	/* .cover-image */
 	background-size: cover;
 	background-position: center;


### PR DESCRIPTION
Trackarts are often changed with some delay, and the controller does not handle these changes. So current trackart is almost always is not actual; when user clicks on extension icon in omnibar, he/she sees coverart of previous song in the info popup. This is true for connectors that have `getTrackArt` overridden function.

I just added updating `trackArt` field, but I don't like it too much. I think sending array of chanded fields to controller is better way to update the new state. But it might break something. :D