### PR TITLE
Don't lookup for metadata on trackname scrolling

### DIFF
--- a/connectors/v2/spotify-play.js
+++ b/connectors/v2/spotify-play.js
@@ -3,8 +3,7 @@
 /* global Connector */
 
 Connector.getArtist = function() {
-	var el = $('#app-player').get(0).contentDocument.getElementById('track-artist');
-	return (el === null) ? null : el.textContent.trim();
+	return $('#app-player').contents().find('#track-artist a').first().text();
 };
 
 Connector.getTrack = function() {

--- a/connectors/v2/spotify-play.js
+++ b/connectors/v2/spotify-play.js
@@ -8,8 +8,7 @@ Connector.getArtist = function() {
 };
 
 Connector.getTrack = function() {
-	var el = $('#app-player').get(0).contentDocument.getElementById('track-name');
-	return (el === null) ? null : el.textContent.trim();
+	return $('#app-player').contents().find('#track-name a').first().text();
 };
 
 Connector.getDuration = function() {


### PR DESCRIPTION
Spotify player has ability to scroll long tracknames by hovering mouse pointer on them. But it causes song metadata lookup, because the `#track-name` element contains two instances of song titles while scrolling the text. So it's enough to read only the first one.