### PR TITLE
Fix Plex track title detection

### DIFF
--- a/connectors/v2/plex.js
+++ b/connectors/v2/plex.js
@@ -6,7 +6,7 @@ Connector.playerSelector = '#plex';
 
 Connector.artistSelector = '.grandparent-title';
 
-Connector.trackSelector = '.item-title';
+Connector.trackSelector = '.title-container .item-title';
 
 Connector.currentTimeSelector = '.player-position';
 


### PR DESCRIPTION
The previous class wasn't sufficiently specific, so it would pull in
extra info and make a match impossible. With this change, the title is
now accurately selected every time.