### PR TITLE
Soundcloud: Handle number signs in song titles

### DIFF
--- a/connectors/v2/soundcloud.js
+++ b/connectors/v2/soundcloud.js
@@ -65,7 +65,6 @@ function cleanArtistTrack() {
  * parse metadata and set local variables
  */
 var setSongData = function (metadata) {
-	artist = '';
 	// Sometimes the artist name is in the track title.
 	// e.g. Tokyo Rose - Zender Overdrive by Aphasia Records.
 	/*jslint regexp: true*/
@@ -73,13 +72,12 @@ var setSongData = function (metadata) {
 		match = regex.exec(metadata.title);
 	/*jslint regexp: false*/
 
-	if (match) {
+	// But don't interpret patterns of the form
+	// "[Start of title] #1234 - [End of title]" as Artist - Title
+	if (match && ! /.*#\d+.*/.test(match[1])) {
 		artist = match[1];
 		track = match[2];
-	}
-
-	// If not, use the username.
-	if (artist === '') {
+	} else {
 		artist = metadata.user.username;
 		track = metadata.title;
 	}


### PR DESCRIPTION
I noticed that I wasn't able to scrobble https://soundcloud.com/amun-dragoon/sets/unlimited-dream-company correctly. This is because the hyphen in the song titles makes the scrobbler incorrectly interpret them as [Artist] - [Title] pairs.

The initial regex, `/(.+)\s?[\-–:]\s?(.+)/`, is definitely a sound one generally. https://soundcloud.com/bandofhorses/sets/iron-wine-and-ben-bridwell, for example, confirms that Soundcloud user name is not an accurate way to decide the artist name, and in that case the regex indeed seems like the only way to find the correct name. But it fails in the case for Amun Dragoon.

I propose an addition to the pattern matching where a song title like "アムン・ヅラグン #3419 - FANTASY BREEZE" won't be interpreted as an [Artist] - [Title] pair, but instead will fall back on the `metadata.user.username` and `metadata.title` values which contain the correct information in this case. This is done by testing the prospecting artist name against `/.*#\d+.*/` and if it matches then the code enters the fallback.

I know that this method isn't foolproof. I don't know if there are artists with number signs and digits in the name -- but I suspected there are -- and then the "[Artist] - [Title]" format would be incorrectly scrobbled as a song title. However, I hope we will have _fewer_ incorrect scrobbles this way.

If anyone knows a better way to get around the issue I would be happy to edit the code.