### PR TITLE
Remove [genre] from the beginning of the title

### DIFF
--- a/connectors/v2/youtube.js
+++ b/connectors/v2/youtube.js
@@ -64,6 +64,8 @@ Connector.isStateChangeAllowed = function() {
 
 Connector.getArtistTrack = function () {
 	var text = $.trim($(Connector.artistTrackSelector).text());
+	
+	text = text.replace(/^\[[^\]]+\]\s*-*\s*/i, ''); // remove [genre] from the beginning of the title
 
 	var separator = Connector.findSeparator(text);
 

--- a/connectors/v2/youtube.js
+++ b/connectors/v2/youtube.js
@@ -64,7 +64,7 @@ Connector.isStateChangeAllowed = function() {
 
 Connector.getArtistTrack = function () {
 	var text = $.trim($(Connector.artistTrackSelector).text());
-	
+
 	text = text.replace(/^\[[^\]]+\]\s*-*\s*/i, ''); // remove [genre] from the beginning of the title
 
 	var separator = Connector.findSeparator(text);


### PR DESCRIPTION
Fixes parsing of Monstercat video titles (example https://www.youtube.com/watch?v=8c0M7p49Acs).
It needs to be done before finding the separator as it will pick the wrong separator otherwise ([genre] - artist - title).