### PR TITLE
Hide token in 'auth.gettoken' response

### DIFF
--- a/core/background/services/lastfm.js
+++ b/core/background/services/lastfm.js
@@ -53,8 +53,6 @@ define([
 		http_request.setRequestHeader('Content-Type', 'application/xml');
 		http_request.send();
 
-		console.log('getToken response: %s', http_request.responseText);
-
 		var xmlDoc = $.parseXML(http_request.responseText);
 		var xml = $(xmlDoc);
 		var status = xml.find('lfm').attr('status');
@@ -71,6 +69,10 @@ define([
 				// set token and reset session so we will grab a new one
 				data.sessionID = null;
 				data.token = xml.find('token').text();
+
+				var response = http_request.responseText;
+				console.log('getToken response: %s', response.replace(data.token, data.token.substr(5)));
+
 				storage.set(data, function() {
 					cb('http://www.last.fm/api/auth/?api_key=' + apiKey + '&token=' + data.token);
 				});

--- a/core/background/services/lastfm.js
+++ b/core/background/services/lastfm.js
@@ -71,7 +71,7 @@ define([
 				data.token = xml.find('token').text();
 
 				var response = http_request.responseText;
-				console.log('getToken response: %s', response.replace(data.token, data.token.substr(5)));
+				console.log('getToken response: %s', response.replace(data.token, 'xxxxx' + data.token.substr(5)));
 
 				storage.set(data, function() {
 					cb('http://www.last.fm/api/auth/?api_key=' + apiKey + '&token=' + data.token);


### PR DESCRIPTION
It's better to hide token automatically by the extension instead of explaining people how to hide it manually (https://github.com/david-sabata/web-scrobbler/issues/981#issuecomment-238158879).