### PR TITLE
Fix Prostopleer URL

### DIFF
--- a/core/connectors.js
+++ b/core/connectors.js
@@ -416,8 +416,8 @@ define(function() {
 		},
 
 		{
-			label: 'Pleer.Com (Prostopleer)',
-			matches: ['*://pleer.com/*', '*://prostopleer.com/*'],
+			label: 'Prostopleer',
+			matches: ['*://pleer.net/*'],
 			js: ['connectors/v2/pleer.js'],
 			version: 2
 		},


### PR DESCRIPTION
Prostopleer changed their URL, and connector was broken.
Also old URL (prostopleer.com) was removed since it redirects to pleer.net.