### PR TITLE
Fix now playing notifications

### DIFF
--- a/core/background/objects/song.js
+++ b/core/background/objects/song.js
@@ -135,7 +135,7 @@ define([
 		 */
 		song.getTrackArt = function() {
 			// prefer parsed art, fall back to metadata (last.fm or coverArtArchive art)
-			return this.parsed.trackArt || this.metadata.trackUrl || null;
+			return this.parsed.trackArt || this.metadata.artistThumbUrl || null;
 		};
 
 		return song;


### PR DESCRIPTION
Web scrobbler was unable to show notifications if coverart of now playing song is not provided by connector. In this case `Song.getTrackArt` function returned a URL to a song page which cannot be used as image:
```
Unchecked runtime.lastError while running notifications.create: Unable to download all specified images.
at createNotification [as callback]
```