### PR TITLE
Print Last.fm response on error

### DIFF
--- a/core/background/services/lastfm.js
+++ b/core/background/services/lastfm.js
@@ -143,8 +143,8 @@ define([
 					cb(response.session);
 				}
 			})
-			.fail(function(jqxhr, textStatus, error) {
-				console.error('auth.getSession failed: ' + error + ', ' + textStatus);
+			.fail(function(jqxhr) {
+				console.error('auth.getSession failed: ' + jqxhr.responseText);
 				cb(null);
 			});
 	}
@@ -216,9 +216,9 @@ define([
 			okCb.apply(this, arguments);
 		};
 
-		var internalErrCb = function(jqXHR, status, response) {
+		var internalErrCb = function(jqXHR) {
 			if (enableLogging) {
-				console.error('L.FM response to ' + url + ' : ' + status + '\n' + response);
+				console.error('L.FM response to ' + url + ' : ' + jqXHR.responseText);
 			}
 
 			errCb.apply(this, arguments);


### PR DESCRIPTION
E.g. print

```
lastfm.js:147 auth.getSession failed: {"error":14,"message":"Unauthorized Token - This token has not been authorized"}
```

instead of

```
lastfm.js:147 auth.getSession failed: Forbidden, error
```

I hope it'll help to solve continuous auth errors.
