### PR TITLE
Improve linting

### DIFF
--- a/.csslintrc
+++ b/.csslintrc
@@ -1,4 +1,4 @@
 {
-	"gradients": false,
-	"ids": false
+  "gradients": false,
+  "ids": false
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,6 @@ insert_final_newline = true
 [*.md]
 trim_trailing_whitespace = false
 
-[package.json]
+[{*.json,.jshintrc,.csslintrc}]
 indent_style = space
 indent_size = 2

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,18 +1,18 @@
 {
-	"browser": true,
-	"curly": true,
-	"esnext": true,
-	"globals": {
-		"$": false,
-		"console": false,
-		"chrome": false,
-		"require": false,
-		"define": false
-	},
-	"globalstrict": true,
-	"quotmark": "single",
-	"smarttabs": true,
-	"trailing": true,
-	"undef": true,
-	"unused": true
+  "browser": true,
+  "curly": true,
+  "esnext": true,
+  "globals": {
+    "$": false,
+    "console": false,
+    "chrome": false,
+    "require": false,
+    "define": false
+  },
+  "globalstrict": true,
+  "quotmark": "single",
+  "smarttabs": true,
+  "trailing": true,
+  "undef": true,
+  "unused": true
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
 
 	var jsConnectorFiles = ['connectors/v2/*.js', 'connectors/22tracks.js']; // intentionally does not contain all files yet
 	var jsCoreFiles = ['Gruntfile.js', 'core/**/*.js', 'options/options.js', 'popups/*.js'];
-	var jsonFiles = ['*.json', '.jshintrc'];
+	var jsonFiles = ['*.json', '.jshintrc', '.csslintrc'];
 	var htmlFiles = ['options/*.html', 'popups/*.html', 'dialogs/**/*.html'];
 	var cssFiles = ['options/options.css', 'popups/base.css', 'dialogs/base.css'];
 
@@ -30,7 +30,7 @@ module.exports = function(grunt) {
 		lintspaces: {
 			all: {
 				src: [
-					jsCoreFiles, jsConnectorFiles, cssFiles, htmlFiles
+					jsCoreFiles, jsConnectorFiles, jsonFiles, cssFiles, htmlFiles
 				],
 
 				options: {
@@ -62,6 +62,6 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-lintspaces');
 	grunt.loadNpmTasks('grunt-jsonlint');
 	grunt.loadNpmTasks('grunt-contrib-csslint');
-	grunt.registerTask('lint', ['jshint', 'csslint']);
-	grunt.registerTask('default', ['lint', 'lintspaces', 'jsonlint']);
+	grunt.registerTask('lint', ['jshint', 'csslint', 'jsonlint', 'lintspaces']);
+	grunt.registerTask('default', ['lint']);
 };

--- a/core/content/connector.js
+++ b/core/content/connector.js
@@ -102,7 +102,7 @@ var BaseConnector = window.BaseConnector || function () {
 		 *
 		 * Push new seprators in the implementation if required.
 		 *
- 		 * @type {array}
+		 * @type {array}
 		 */
 		this.separators = [' -- ', '--', ' - ', ' – ', ' — ', '-', '–', '—', ':', '|', '///'];
 

--- a/manifest.json
+++ b/manifest.json
@@ -9,41 +9,41 @@
     "128": "icon128.png"
   },
 
-   "manifest_version": 2,
-   "content_security_policy": "script-src 'self' https://www.google-analytics.com/analytics.js; object-src 'self'",
+  "manifest_version": 2,
+  "content_security_policy": "script-src 'self' https://www.google-analytics.com/analytics.js; object-src 'self'",
 
-   "web_accessible_resources": [
-      "icon128.png",
-      "connectors/v2/soundcloud-dom-inject.js"
-   ],
+  "web_accessible_resources": [
+    "icon128.png",
+    "connectors/v2/soundcloud-dom-inject.js"
+  ],
 
-   "background": {
-      "scripts": [
-	      "vendor/require.js", "core/background/requirejs-config.js",
-	      "core/background/main.js"
-      ]
-   },
+  "background": {
+    "scripts": [
+      "vendor/require.js", "core/background/requirejs-config.js",
+      "core/background/main.js"
+    ]
+  },
 
-   "options_page": "options/options.html",
+  "options_page": "options/options.html",
 
-   "permissions": [
-      "tabs",
-      "notifications",
-      "storage",
-      "https://ws.audioscrobbler.com/2.0/",
-      "https://gdata.youtube.com/feeds/api/videos/",
-      "http://*/",
-      "https://*/"
-   ],
+  "permissions": [
+    "tabs",
+    "notifications",
+    "storage",
+    "https://ws.audioscrobbler.com/2.0/",
+    "https://gdata.youtube.com/feeds/api/videos/",
+    "http://*/",
+    "https://*/"
+  ],
 
-   "page_action": {
-      "chromeBroken": "remove this line after issue #86449 is resolved"
-   },
+  "page_action": {
+    "chromeBroken": "remove this line after issue #86449 is resolved"
+  },
 
-   "content_scripts": [
-      {
-         "matches": ["<all_urls>"],
-         "js": ["connectors/dummy.js"]
-      }
-   ]
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["connectors/dummy.js"]
+    }
+  ]
 }


### PR DESCRIPTION
#### Changelog:
* Add rules for `.jshintrc` and `.csslintrc`;
* Allow lintspaces to lint json files;
* Fix indentation of json files to match `.editorconfig` rules;
* Run jsonlint and lintspaces by `grunt lint` command.

I did not change any file content, just fixed the indentation.

I also included an indentation fix of 'connector' module in this PR. Actually, jshint ignores JS comments, and this change doesn't affect on jshinting. I fixed it to satisfy the internal 'mixed-indent' linter.