### PR TITLE
Move the 'Two MutationObservers' pattern logic to core

### DIFF
--- a/connectors/v2/alexa.js
+++ b/connectors/v2/alexa.js
@@ -2,27 +2,7 @@
 
 /* global Connector */
 
-(function() {
-		var playerObserver = new MutationObserver(function() {
-		if (document.querySelector('#d-content')) {
-			playerObserver.disconnect();
-			var actualObserver = new MutationObserver(Connector.onStateChanged);
-			actualObserver.observe(document.querySelector('#d-content'), {
-				childList: true,
-				subtree: true,
-				attributes: true,
-				characterData: true
-			});
-		}
-	});
-
-	playerObserver.observe(document.body, {
-		childList: true,
-		subtree: true,
-		attributes: false,
-		characterData: false
-	});
-})();
+Connector.playerSelector = '#d-content';
 
 var isPlayingLiveRadio = function() {
 	if ($('#d-secondary-control-left .disabled').size() === 1 && $('#d-secondary-control-right .disabled').size() === 1) {

--- a/connectors/v2/cubicfm.js
+++ b/connectors/v2/cubicfm.js
@@ -2,27 +2,7 @@
 
 /* global Connector */
 
-(function() {
-		var playerObserver = new MutationObserver(function() {
-		if (document.querySelector('.player')) {
-			playerObserver.disconnect();
-			var actualObserver = new MutationObserver(Connector.onStateChanged);
-			actualObserver.observe(document.querySelector('.player'), {
-				childList: true,
-				subtree: true,
-				attributes: true,
-				characterData: true
-			});
-		}
-	});
-
-	playerObserver.observe(document.body, {
-		childList: true,
-		subtree: true,
-		attributes: false,
-		characterData: false
-	});
-})();
+Connector.playerSelector = '.player';
 
 Connector.artistTrackSelector = '.track-mobile-songtitle';
 

--- a/connectors/v2/kollekt.js
+++ b/connectors/v2/kollekt.js
@@ -2,29 +2,7 @@
 
 /* global Connector */
 
-(function() {
-	var playerObserver = new MutationObserver(function() {
-		if (document.getElementById('player-controls')) {
-			playerObserver.disconnect();
-			var actualObserver = new MutationObserver(Connector.onStateChanged);
-			actualObserver.observe(document.querySelector('#player-controls'), {
-				childList: true,
-				subtree: true,
-				attributes: true,
-				characterData: true
-			});
-		}
-	});
-
-	playerObserver.observe(document.body, {
-		childList: true,
-		subtree: true,
-		attributes: false,
-		characterData: false,
-	});
-
-})();
-
+Connector.playerSelector = '#player-controls';
 
 Connector.artistTrackSelector = '.current-track-title > span';
 

--- a/connectors/v2/nrkradio.js
+++ b/connectors/v2/nrkradio.js
@@ -2,6 +2,8 @@
 
 /* global Connector */
 
+Connector.playerSelector = '.pi-infobox';
+
 Connector.getArtistTrack = function () {
 	var text = $('.active.music .fnn-title').text();
 	var separator = this.findSeparator(text);
@@ -16,27 +18,3 @@ Connector.getArtistTrack = function () {
 
 	return {artist: artist, track: track};
 };
-
-(function() {
-	var playerObserver = new MutationObserver(function() {
-		var playerElement = document.querySelector('.pi-infobox');
-		if (playerElement !== null) {
-			playerObserver.disconnect();
-			var actualObserver = new MutationObserver(Connector.onStateChanged);
-			actualObserver.observe(playerElement, {
-				childList: true,
-				subtree: true,
-				attributes: true,
-				characterData: true
-			});
-		}
-	});
-
-	playerObserver.observe(document.body, {
-		childList: true,
-		subtree: true,
-		attributes: false,
-		characterData: false,
-	});
-
-})();

--- a/connectors/v2/pitchfork.js
+++ b/connectors/v2/pitchfork.js
@@ -2,6 +2,8 @@
 
 /* global Connector */
 
+Connector.playerSelector = '#player-container';
+
 Connector.artistSelector = '.track-title .artist';
 
 Connector.trackSelector = '.track-title .title';
@@ -9,27 +11,3 @@ Connector.trackSelector = '.track-title .title';
 Connector.isPlaying = function () {
 	return $('.playback-button > div').attr('title') === 'Pause Track';
 };
-
-(function() {
-	var playerObserver = new MutationObserver(function() {
-		var playerElement = document.querySelector('#player-container');
-		if (playerElement !== null) {
-			playerObserver.disconnect();
-			var actualObserver = new MutationObserver(Connector.onStateChanged);
-			actualObserver.observe(playerElement, {
-				childList: true,
-				subtree: true,
-				attributes: true,
-				characterData: true
-			});
-		}
-	});
-
-	playerObserver.observe(document.body, {
-		childList: true,
-		subtree: true,
-		attributes: false,
-		characterData: false,
-	});
-
-})();

--- a/connectors/v2/radioplusbe.js
+++ b/connectors/v2/radioplusbe.js
@@ -11,27 +11,3 @@ Connector.trackSelector = '.info .song';
 Connector.isPlaying = function () {
 	return $('.audio-controller .any-surfer').text() === 'Stop de radiospeler';
 };
-
-(function() {
-	var playerObserver = new MutationObserver(function() {
-		var playerElement = document.querySelector('.audio-controller');
-		if (playerElement !== null) {
-			playerObserver.disconnect();
-			var actualObserver = new MutationObserver(Connector.onStateChanged);
-			actualObserver.observe(playerElement, {
-				childList: true,
-				subtree: true,
-				attributes: true,
-				characterData: true
-			});
-		}
-	});
-
-	playerObserver.observe(document.body, {
-		childList: true,
-		subtree: true,
-		attributes: false,
-		characterData: false,
-	});
-
-})();


### PR DESCRIPTION
These changes only affects on websites which have 'delayed' player element.

I didn't remove MutationObservers usage from some connectors since their logic is more complex than in the original implementation.
