### PR TITLE
Fix reading options

### DIFF
--- a/core/background/notifications.js
+++ b/core/background/notifications.js
@@ -23,7 +23,7 @@ define([
 	 * Checks for user configuration
 	 */
 	function isAllowed() {
-		return localStorage.useNotifications === 1;
+		return localStorage.useNotifications === '1';
 	}
 
 	/**

--- a/core/background/services/background-ga.js
+++ b/core/background/services/background-ga.js
@@ -28,7 +28,7 @@ define(function() {
 	 * @param {...*}
 	 */
 	function send() {
-		if (localStorage.disableGa === 1) {
+		if (localStorage.disableGa === '1') {
 			return;
 		}
 
@@ -41,7 +41,7 @@ define(function() {
 	 * @param {...*}
 	 */
 	function event() {
-		if (localStorage.disableGa === 1) {
+		if (localStorage.disableGa === '1') {
 			return;
 		}
 

--- a/options/options.js
+++ b/options/options.js
@@ -17,19 +17,19 @@ require([
 		// preload values and attach listeners
 
 		$('#use-notifications')
-			.attr('checked', (localStorage.useNotifications === 1))
+			.attr('checked', (localStorage.useNotifications === '1'))
 			.click(function () {
 				localStorage.useNotifications = this.checked ? 1 : 0;
 			});
 
 		$('#use-autocorrect')
-			.attr('checked', (localStorage.useAutocorrect === 1))
+			.attr('checked', (localStorage.useAutocorrect === '1'))
 			.click(function () {
 				localStorage.useAutocorrect = this.checked ? 1 : 0;
 			});
 
 		$('#disable-ga')
-			.attr('checked', (localStorage.disableGa === 1))
+			.attr('checked', (localStorage.disableGa === '1'))
 			.click(function () {
 				localStorage.disableGa = this.checked ? 1 : 0;
 			});


### PR DESCRIPTION
Was broken in #1120.

All values in localStorage are stored as strings.