### PR TITLE
Add amazon.co.jp

### DIFF
--- a/core/connectors.js
+++ b/core/connectors.js
@@ -146,10 +146,12 @@ define(function() {
 				'*://www.amazon.de/gp/dmusic/cloudplayer/*',
 				'*://www.amazon.es/gp/dmusic/cloudplayer/*',
 				'*://www.amazon.co.uk/gp/dmusic/cloudplayer/*',
+				'*://www.amazon.co.jp/gp/dmusic/cloudplayer/*',
 				'*://music.amazon.com/*',
 				'*://music.amazon.de/*',
 				'*://music.amazon.es/*',
-				'*://music.amazon.co.uk/*'],
+				'*://music.amazon.co.uk/*',
+				'*://music.amazon.co.jp/*'],
 			js: ['connectors/v2/amazon.js'],
 			version: 2
 		},


### PR DESCRIPTION
amazon.co.jp also services prime music, so extend the patterns for Amazon to include it.
