### PR TITLE
Fix EgoFM connector

### DIFF
--- a/connectors/v2/ego-fm.js
+++ b/connectors/v2/ego-fm.js
@@ -2,23 +2,10 @@
 
 /* global Connector */
 
-Connector.playerSelector = '#playerInfo';
+Connector.playerSelector = '.radioplayer-head';
 
-Connector.artistSelector = '#current > span.artist';
+Connector.artistTrackSelector = '.scrolling-text';
 
 Connector.trackSelector = '#current > span.song';
 
-Connector.isPlaying = function () {
-	var spanelement = document.querySelector('.now');
-	if(spanelement !== null)
-	{
-		if( spanelement.innerHTML === 'Jetzt:')
-		{
-			return true;
-		}
-	}
-	else
-	{
-		return false;
-	}
-};
+Connector.playButtonSelector = 'button.play';

--- a/core/connectors.js
+++ b/core/connectors.js
@@ -821,7 +821,7 @@ define(function() {
 		},
 		{
 			label: 'Ego FM',
-			matches: ['*://www.egofm.de/*'],
+			matches: ['*://www.egofm.de/*', '*://player.addradio.de/player/2366*'],
 			js: ['connectors/v2/ego-fm.js'],
 			version: 2
 		},


### PR DESCRIPTION
EgoFM's player isn't located at main website directly, so I've left a dummy URL pattern to make sure the user is noticed the EgoFM is supported by the extension. :) Also, see my question about this case in Gitter chat.