### PR TITLE
Implement shared metadata filter

### DIFF
--- a/connectors/v2/alexa.js
+++ b/connectors/v2/alexa.js
@@ -20,7 +20,7 @@ Connector.getArtist = function() {
 			return null;
 		}
 		var results = songTitle.split('-');
-		return results[0].trim();
+		return results[0];
 	} else {
 		return $('#d-info-text .d-sub-text-1').text();
 	}
@@ -34,7 +34,7 @@ Connector.getTrack = function() {
 			return null;
 		}
 		var results = songTitle.split('-');
-		return results[1].trim();
+		return results[1];
 	} else {
 		return $('#d-info-text .d-main-text').text();
 	}

--- a/connectors/v2/archive.js
+++ b/connectors/v2/archive.js
@@ -24,9 +24,7 @@ function bindNew() {
 
 	Connector.currentTimeSelector = '#jw6_controlbar_elapsed';
 
-	Connector.getAlbum = function() {
-		return $('#wrap > div:nth-child(6) > div > div.col-sm-8.thats-left > h1').text().trim() || null;
-	};
+	Connector.albumSelector = '#wrap > div:nth-child(6) > div > div.col-sm-8.thats-left > h1';
 
 	Connector.getArtist = function() {
 		return parseArtist();
@@ -37,7 +35,7 @@ function bindNew() {
 
 		var parts = track.split('-');
 		if (parts.length === 3 && parts[0].trim() === parseArtist()) {
-			track = parts[2].trim();
+			track = parts[2];
 		}
 
 		return track;
@@ -69,7 +67,7 @@ function bindLegacy() {
 		// Remove artist from album
 		var parts = album.split('-');
 		if (parts.length > 0 && parts[0].trim() === parseArtist()) {
-			album = album.substr(album.indexOf('-') + 1).trim();
+			album = album.substr(album.indexOf('-') + 1);
 		}
 
 		return album;
@@ -86,7 +84,7 @@ function bindLegacy() {
 		// Some titles are stored as artist - track # - title so strip out non-title elements
 		var parts = title.split('-');
 		if (parts.length === 3 && parts[0].trim() === parseArtist()) {
-			title = parts[2].trim();
+			title = parts[2];
 		}
 
 		return title;

--- a/connectors/v2/bandcamp.js
+++ b/connectors/v2/bandcamp.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global Connector */
+/* global Connector, MetadataFilter */
 
 /** note: the discover page doesn't display the track artist for compilation albums.  This connector
     currently passes 'Various Artist' (or other variant) as the artist name so tracks on albums with
@@ -8,18 +8,6 @@
 
 // wire audio element to fire state changes
 $('audio').bind('playing pause timeupdate', Connector.onStateChanged);
-
-/**
- * remove zero width characters & trim
- * @param  {string} text to clean up
- * @return {string} cleaned up text
- */
-function cleanText(input) {
-	if (input === null) {
-		return input;
-	}
-	return input.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
-}
 
 function getArtist() {
 	var artist = $('.detail_item_link_2').text() ||
@@ -29,7 +17,7 @@ function getArtist() {
 	if (artist === null) {
 		artist = $('.waypoint-artist-title').text().substr(3);
 	}
-	return cleanText(artist);
+	return artist;
 }
 
 function getTrack() {
@@ -39,7 +27,7 @@ function getTrack() {
 				$('.waypoint-item-title').text() ||
 				$('.track_info .title') ||
 				null;
-	return cleanText(track);
+	return track;
 }
 
 function artistIsVarious() {
@@ -69,8 +57,8 @@ Connector.getArtistTrack = function () {
 		separatorIndex;
 	if (artistIsVarious()) {
 		separatorIndex = Math.max(track.indexOf('-'), track.indexOf('|'));
-		artist = cleanText(track.substring(0, separatorIndex));
-		track = cleanText(track.substring(separatorIndex + 1));
+		artist = track.substring(0, separatorIndex);
+		track = track.substring(separatorIndex + 1);
 	}
 	return {
 		artist: artist,
@@ -83,7 +71,7 @@ Connector.getAlbum = function () {
 				$('h2.trackTitle').text() ||
 				$('[itemprop="inAlbum"] [itemprop="name"]').text() ||
 				null;
-	return cleanText(album);
+	return album;
 };
 
 Connector.playButtonSelector = 'div.playbutton:not(.playing)';
@@ -111,3 +99,7 @@ Connector.getUniqueID = function () {
 	}
 	return null;
 };
+
+Connector.filter = new MetadataFilter({
+	all: [MetadataFilter.removeZeroWidth, MetadataFilter.trim]
+});

--- a/connectors/v2/bandzone.cz.js
+++ b/connectors/v2/bandzone.cz.js
@@ -1,19 +1,13 @@
 'use strict';
 
-/* global Connector */
+/* global Connector, MetadataFilter */
 
 if (location.href === 'http://bandzone.cz/' || location.href === 'https://bandzone.cz/') {
 	Connector.playerSelector = '#stats';
 
-	Connector.getArtist = function () {
-		var text = $('.stat:has(.ui-miniaudioplayer-state-playing) h4').text().trim();
-		return text || null;
-	};
+	Connector.artistSelector = '.stat:has(.ui-miniaudioplayer-state-playing) h4';
 
-	Connector.getTrack = function () {
-		var text = $('.stat:has(.ui-miniaudioplayer-state-playing) .songTitle').text().trim();
-		return text || null;
-	};
+	Connector.trackSelector = '.stat:has(.ui-miniaudioplayer-state-playing) .songTitle';
 
 	Connector.isPlaying = function () {
 		return $('.ui-miniaudioplayer-state-playing').length;
@@ -21,10 +15,7 @@ if (location.href === 'http://bandzone.cz/' || location.href === 'https://bandzo
 } else {
 	Connector.playerSelector = '#playerWidget';
 
-	Connector.getArtist = function () {
-		var text = $('.profile-name h1').text().replace($('.profile-name span').text(), '').trim();
-		return text || null;
-	};
+	Connector.artistSelector = '.profile-name h1';
 
 	Connector.trackSelector = '.ui-state-active .ui-audioplayer-song-title';
 
@@ -42,11 +33,21 @@ if (location.href === 'http://bandzone.cz/' || location.href === 'https://bandzo
 		return Connector.stringToSeconds(durationStr);
 	};
 
+	Connector.filter = new MetadataFilter({
+		all: MetadataFilter.trim,
+		artist: removeGenre
+	});
+
 	var INFO_CURRENT_TIME = 1;
 	var INFO_DURATION = 2;
 	var getSongInfo = function(field) {
 		var infoStr = $('.ui-audioplayer-time').text();
 		var pattern = /(.+)\s\/\s(.+)/gi;
 		return pattern.exec(infoStr)[field];
+	};
+
+	var removeGenre = function(text) {
+		var genre = $('.profile-name span').text();
+		return text.replace(genre, '');
 	};
 }

--- a/connectors/v2/dreamfm.js
+++ b/connectors/v2/dreamfm.js
@@ -1,38 +1,14 @@
 'use strict';
 
-/* global Connector */
+/* global Connector, MetadataFilter */
 
 Connector.playerSelector = '#player';
 
-/**
- * remove zero width characters & trim
- * @param  {string} text to clean up
- * @return {string} cleaned up text
- */
-function cleanText(input) {
-	if (input === null) {
-		return input;
-	}
-	return input.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
-}
+Connector.artistSelector = '#tracka';
 
-Connector.getArtist = function() {
-	var artist = $('#tracka').text() ||
-				null;
-	return cleanText(artist);
-};
+Connector.trackSelector = '#tracktitle';
 
-Connector.getTrack = function() {
-	var track = $('#tracktitle').text() ||
-				null;
-	return cleanText(track);
-};
-
-Connector.getAlbum = function () {
-	var album = $('#album').text() ||
-				null;
-	return cleanText(album);
-};
+Connector.albumSelector = '#album';
 
 Connector.isPlaying = function() {
 	var e = $('.play-pause .play');
@@ -58,3 +34,7 @@ Connector.getUniqueID = function () {
 	}
 	return null;
 };
+
+Connector.filter = new MetadataFilter({
+	all: [MetadataFilter.removeZeroWidth, MetadataFilter.trim]
+});

--- a/connectors/v2/driveplayer.com.js
+++ b/connectors/v2/driveplayer.com.js
@@ -3,15 +3,9 @@
 /* global Connector */
 Connector.playerSelector = '.jp-audio';
 
-Connector.getArtist = function () {
-	var text = $('.playing > .artist').text().trim();
-	return text || null;
-};
+Connector.artistSelector = '.playing > .artist';
 
-Connector.getTrack = function () {
-	var text = $('.playing > .title').text().trim();
-	return text || null;
-};
+Connector.trackSelector = '.playing > .title';
 
 Connector.playButtonSelector = '.jp-play';
 

--- a/connectors/v2/farfrommoscow.js
+++ b/connectors/v2/farfrommoscow.js
@@ -28,8 +28,8 @@ Connector.getArtistTrack = function () {
 		var separator = this.findSeparator(text);
 
 		if (separator !== null) {
-			artist = text.substr(0, separator.index).trim();
-			track = text.substr(separator.index + separator.length).trim();
+			artist = text.substr(0, separator.index);
+			track = text.substr(separator.index + separator.length);
 		}
 	} else if ($('.Hello-Mini-Playing').length) {
 		artist = $('.H-artist').text();

--- a/connectors/v2/freemusicarchive.js
+++ b/connectors/v2/freemusicarchive.js
@@ -54,18 +54,18 @@ Connector.getArtist = function () {
 	/*jslint regexp: true*/
 	switch (pageType) {
 	case 'artist':
-		return $('div.bcrumb h1').contents().filter(function () { return this.nodeType === 3; }).text().trim();
+		return $('div.bcrumb h1').contents().filter(function () { return this.nodeType === 3; }).text();
 	case 'album':
 		// if there are two anchors in the .playtxt span then it uses the format "Artist - TrackName" (albums with Various Artists)
 		if ($('div.gcol-electronic .playtxt a').length === 2) {
-			return $('div.gcol-electronic .playtxt a').first().text().trim();
+			return $('div.gcol-electronic .playtxt a').first().text();
 		}
 		return searchComment(/\[artist_name\] => (.+)/);
 	case 'song':
 		// return $('a[property="cc:attributionName"]').text();  //can't use, attribution isn't always present
 		return searchComment(/\[artist_name\] => (.+)/);
 	default:
-		return $('div.gcol-electronic .playtxt a').first().text().trim();
+		return $('div.gcol-electronic .playtxt a').first().text();
 	}
 };
 

--- a/connectors/v2/groovemusic.js
+++ b/connectors/v2/groovemusic.js
@@ -12,7 +12,7 @@ Connector.trackSelector = '#player .primaryMetadata a:first';
 
 Connector.getAlbum = function() {
 	var album = $('#player .imgWrapper .img').attr('alt');
-	album = album.substr(album.indexOf('-')+1).trim();
+	album = album.substr(album.indexOf('-')+1);
 	return album || null;
 };
 

--- a/connectors/v2/jamendo.js
+++ b/connectors/v2/jamendo.js
@@ -4,6 +4,10 @@
 
 Connector.playerSelector = '#skeleton-player';
 
+Connector.artistSelector = '.player-mini_track_information_artist';
+
+Connector.trackSelector = '.player-mini_track_information_title';
+
 Connector.currentTimeSelector = '.hidden-xs > .js-player-position';
 
 Connector.durationSelector = '.hidden-xs > .js-player-duration';
@@ -11,13 +15,3 @@ Connector.durationSelector = '.hidden-xs > .js-player-duration';
 Connector.playButtonSelector = '.js-player-play-pause > .icon-play';
 
 Connector.trackArtImageSelector = '.js-full-player-cover-img';
-
-Connector.getArtist = function () {
-	var text = $('.player-mini_track_information_artist').text();
-	return $.trim(text);
-};
-
-Connector.getTrack = function () {
-	var text = $('.player-mini_track_information_title').text();
-	return $.trim(text);
-};

--- a/connectors/v2/jango.js
+++ b/connectors/v2/jango.js
@@ -6,10 +6,7 @@ Connector.playerSelector = '#masthead';
 
 Connector.artistSelector = '#player_current_artist a';
 
-Connector.getTrack = function () {
-	var text = $('#current-song').text().trim();
-	return text || null;
-};
+Connector.trackSelector = '#current-song';
 
 Connector.isPlaying = function () {
 	return $('#btn-playpause').hasClass('pause');

--- a/connectors/v2/letournedisque.js
+++ b/connectors/v2/letournedisque.js
@@ -6,10 +6,7 @@ Connector.playerSelector = '.lecteur';
 
 Connector.artistSelector = '.artiste .inside_call';
 
-Connector.getTrack = function () {
-	var text = $('.info-text .name').text().trim();
-	return text || null;
-};
+Connector.trackSelector = '.info-text .name';
 
 Connector.isPlaying = function () {
 	return $('.playing').length > 0;

--- a/connectors/v2/mojepolskieradio.js
+++ b/connectors/v2/mojepolskieradio.js
@@ -5,12 +5,12 @@
 Connector.playerSelector = '#cM';
 
 Connector.getArtist = function () {
-	var text = $('.present .artist').first().text().trim();
+	var text = $('.present .artist').first().text();
 	return text || null;
 };
 
 Connector.getTrack = function () {
-	var text = $('.present .title').first().text().trim();
+	var text = $('.present .title').first().text();
 	return text || null;
 };
 

--- a/connectors/v2/musicload.js
+++ b/connectors/v2/musicload.js
@@ -11,7 +11,7 @@ Connector.getTrackArt = function () {
 };
 
 Connector.getTrack = function() {
-	return $('.player-info-wrapper > .info > .title').contents().get(0).nodeValue.trim();
+	return $('.player-info-wrapper > .info > .title').contents().get(0).nodeValue;
 };
 
 Connector.getAlbum = function () {

--- a/connectors/v2/noisetrade.js
+++ b/connectors/v2/noisetrade.js
@@ -56,17 +56,17 @@ Connector.albumSelector = '.col_album_titles h1.artist';
 Connector.getArtistTrack = function () {
 	// the position of artist & album were switched but the class names
 	//  weren't updated (artist has class name of "album")
-	var artist = $('.col_album_titles h2.album a').text().trim() || null,
-		track = $('a.jp-playlist-current').text().trim() || null,
+	var artist = $('.col_album_titles h2.album a').text() || null,
+		track = $('a.jp-playlist-current').text() || null,
 		execResult;
 	if (trackTitlesStartWithTrackNo) {
-		track = track.substring(2).trim();
+		track = track.substring(2);
 	}
 	if (albumHasVariousArtists) {
 		execResult = /([\w\W]+)\s?-\s?([\w\W]+)/.exec(track);
 		if (execResult) {
-			artist = execResult[1].trim();
-			track = execResult[2].trim();
+			artist = execResult[1];
+			track = execResult[2];
 		}
 	}
 	return {

--- a/connectors/v2/novaplanet.js
+++ b/connectors/v2/novaplanet.js
@@ -4,10 +4,7 @@
 
 Connector.playerSelector = '.radio-radionova';
 
-Connector.getArtist = function () {
-	var text = $('.artist').text().trim();
-	return text || null;
-};
+Connector.artistSelector = '.artist';
 
 Connector.trackSelector = '.ontheair-text .title';
 

--- a/connectors/v2/nrkradio.js
+++ b/connectors/v2/nrkradio.js
@@ -4,17 +4,4 @@
 
 Connector.playerSelector = '.pi-infobox';
 
-Connector.getArtistTrack = function () {
-	var text = $('.active.music .fnn-title').text();
-	var separator = this.findSeparator(text);
-
-	var artist = null;
-	var track = null;
-
-	if (separator !== null) {
-		artist = text.substr(0, separator.index).trim();
-		track = text.substr(separator.index + separator.length).trim();
-	}
-
-	return {artist: artist, track: track};
-};
+Connector.artistTrackSelector = '.active.music .fnn-title';

--- a/connectors/v2/pakartot.js
+++ b/connectors/v2/pakartot.js
@@ -9,13 +9,3 @@ Connector.artistSelector = 'div.jp-player-artist > a';
 Connector.trackSelector = 'div.jp-player-title > a';
 
 Connector.playButtonSelector = '.jp-play';
-
-Connector.getArtist = function() {
-	var text = $(this.artistSelector).text().trim();
-	return text || null;
-};
-
-Connector.getTrack = function() {
-	var text = $(this.trackSelector).text().trim();
-	return text || null;
-};

--- a/connectors/v2/plugdj.js
+++ b/connectors/v2/plugdj.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global Connector */
+/* global Connector, YoutubeFilter */
 
 (function () {
 	var appContainer = document.querySelector('#app');
@@ -35,9 +35,8 @@
 
 Connector.artistTrackSelector = '#now-playing-media .bar-value';
 
-// Stolen from the YouTube v2 connector.
 Connector.getArtistTrack = function () {
-	var text = $.trim($(Connector.artistTrackSelector).text());
+	var text = $(Connector.artistTrackSelector).text();
 
 	var separator = Connector.findSeparator(text);
 
@@ -48,41 +47,10 @@ Connector.getArtistTrack = function () {
 	var artist =  text.substr(0, separator.index);
 	var track = text.substr(separator.index + separator.length);
 
-	/**
-	* Clean non-informative garbage from title
-	*/
-
-	// Do some cleanup
-	artist = artist.replace(/^\s+|\s+$/g,'');
-	track = track.replace(/^\s+|\s+$/g,'');
-
-	// Strip crap
-	track = track.replace(/\s*\*+\s?\S+\s?\*+$/, ''); // **NEW**
-	track = track.replace(/\s*\[[^\]]+\]$/, ''); // [whatever]
-	track = track.replace(/\s*\([^\)]*version\)$/i, ''); // (whatever version)
-	track = track.replace(/\s*\.(avi|wmv|mpg|mpeg|flv)$/i, ''); // video extensions
-	track = track.replace(/\s*(LYRIC VIDEO\s*)?(lyric video\s*)/i, ''); // (LYRIC VIDEO)
-	track = track.replace(/\s*(Official Track Stream*)/i, ''); // (Official Track Stream)
-	track = track.replace(/\s*(of+icial\s*)?(music\s*)?video/i, ''); // (official)? (music)? video
-	track = track.replace(/\s*(of+icial\s*)?(music\s*)?audio/i, ''); // (official)? (music)? audio
-	track = track.replace(/\s*(ALBUM TRACK\s*)?(album track\s*)/i, ''); // (ALBUM TRACK)
-	track = track.replace(/\s*(COVER ART\s*)?(Cover Art\s*)/i, ''); // (Cover Art)
-	track = track.replace(/\s*\(\s*of+icial\s*\)/i, ''); // (official)
-	track = track.replace(/\s*\(\s*[0-9]{4}\s*\)/i, ''); // (1999)
-	track = track.replace(/\s+\(\s*(HD|HQ)\s*\)$/, ''); // HD (HQ)
-	track = track.replace(/\s+(HD|HQ)\s*$/, ''); // HD (HQ)
-	track = track.replace(/\s*video\s*clip/i, ''); // video clip
-	track = track.replace(/\s*full\s*album/i, ''); // Full Album
-	track = track.replace(/\s+\(?live\)?$/i, ''); // live
-	track = track.replace(/\(+\s*\)+/, ''); // Leftovers after e.g. (official video)
-	track = track.replace(/^(|.*\s)"(.*)"(\s.*|)$/, '$2'); // Artist - The new "Track title" featuring someone
-	track = track.replace(/^(|.*\s)'(.*)'(\s.*|)$/, '$2'); // 'Track title'
-	track = track.replace(/^[\/\s,:;~-\s"]+/, ''); // trim starting white chars and dash
-	track = track.replace(/[\/\s,:;~-\s"\s!]+$/, ''); // trim trailing white chars and dash
-	//" and ! added because some track names end as {"Some Track" Official Music Video!} and it becomes {"Some Track"!} example: http://www.youtube.com/watch?v=xj_mHi7zeRQ
-
 	return {artist: artist, track: track};
 };
+
+Connector.filter = YoutubeFilter;
 
 Connector.isPlaying = function () {
 	var timeLeft = $.trim($('#now-playing-time').text());

--- a/connectors/v2/solayo.js
+++ b/connectors/v2/solayo.js
@@ -11,7 +11,7 @@ Connector.artistTrackSelector = '.videoTitle.noColorLink';
 Connector.getArtistTrack = function () {
 	if ($(Connector.artistTrackSelector).text().match(/ - /g).length === 2) {
 		var arr = $(Connector.artistTrackSelector).text().split(' - ');
-		return {artist: arr[1].trim(), track: arr[2].trim()};
+		return {artist: arr[1], track: arr[2]};
 	}
 	var text = $(this.artistTrackSelector).text();
 	var separator = this.findSeparator(text);

--- a/connectors/v2/soundcloud.js
+++ b/connectors/v2/soundcloud.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global Connector */
+/* global Connector, YoutubeFilter */
 
 window.SC_ATTACHED = window.SC_ATTACHED || false;
 var artist, track, duration,
@@ -31,36 +31,7 @@ Connector.getTrackArt = function () {
 	return artwork_url || null;
 };
 
-/**
- * Clean non-informative garbage from title
- */
-function cleanArtistTrack() {
-	/*jslint regexp: true*/
-	// trim whitespace
-	artist = artist.replace(/^\s+|\s+$/g, '');
-	track = track.replace(/^\s+|\s+$/g, '');
-
-	// Strip crap
-	track = track.replace(/^\d+\.\s*/, ''); // 01.
-	track = track.replace(/\s*\*+\s?\S+\s?\*+$/, ''); // **NEW**
-	track = track.replace(/\s*\[[^\]]+\]$/, ''); // [whatever]
-	track = track.replace(/\s*\([^\)]*version\)$/i, ''); // (whatever version)
-	track = track.replace(/\s*\.(avi|wmv|mpg|mpeg|flv)$/i, ''); // video extensions
-	track = track.replace(/\s*(of+icial\s*)?(music\s*)?video/i, ''); // (official)? (music)? video
-	track = track.replace(/\s*\(\s*of+icial\s*\)/i, ''); // (official)
-	track = track.replace(/\s*\(\s*[0-9]{4}\s*\)/i, ''); // (1999)
-	track = track.replace(/\s+\(\s*(HD|HQ)\s*\)$/, ''); // HD (HQ)
-	track = track.replace(/\s+(HD|HQ)\s*$/, ''); // HD (HQ)
-	track = track.replace(/\s*video\s*clip/i, ''); // video clip
-	track = track.replace(/\s+\(?live\)?$/i, ''); // live
-	track = track.replace(/\(\s*\)/, ''); // Leftovers after e.g. (official video)
-	track = track.replace(/^(|.*\s)"(.*)"(\s.*|)$/, '$2'); // Artist - The new "Track title" featuring someone
-	track = track.replace(/^(|.*\s)'(.*)'(\s.*|)$/, '$2'); // 'Track title'
-	track = track.replace(/^[\/\s,:;~\-]+/, ''); // trim starting white chars and dash
-	track = track.replace(/[\/\s,:;~\-]+$/, ''); // trim trailing white chars and dash
-	/*jslint regexp: false*/
-}
-
+Connector.filter = YoutubeFilter;
 /**
  * parse metadata and set local variables
  */
@@ -81,8 +52,6 @@ var setSongData = function (metadata) {
 		artist = metadata.user.username;
 		track = metadata.title;
 	}
-
-	cleanArtistTrack();
 
 	duration = Math.floor(metadata.duration / 1000);
 	// use permalink url as the unique id

--- a/connectors/v2/superplayer.fm.js
+++ b/connectors/v2/superplayer.fm.js
@@ -4,15 +4,9 @@
 
 Connector.playerSelector = '#content';
 
-Connector.getArtist = function () {
-	var text = $('[data-value=artist]').text().trim();
-	return text || null;
-};
+Connector.artistSelector = '[data-value=artist]';
 
-Connector.getTrack = function () {
-	var text = $('[data-value=name]').text().trim();
-	return text || null;
-};
+Connector.trackSelector = '[data-value=name]';
 
 Connector.isPlaying = function () {
 	return !$('[data-action="pause"]').hasClass('active');

--- a/connectors/v2/vk.js
+++ b/connectors/v2/vk.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global Connector */
+/* global Connector, MetadataFilter */
 
 var INFO_ID = 0;
 var INFO_TRACK = 3;
@@ -35,27 +35,16 @@ function updateTrackInfo() {
 	trackInfo = JSON.parse(localStorage.getItem('audio_v10_track'));
 }
 
-/**
- * Decodes HTML entities in given text string
- * @param  {String} str String with HTML entities
- * @return {String}     Decoded string
- */
-var decodeHtmlEntity = function(str) {
-	if (str === null) {
-		return null;
-	}
-
-	return str.replace(/&#(\d+);/g, function(match, dec) {
-		return String.fromCharCode(dec);
-	});
-};
+Connector.filter = new MetadataFilter({
+	all: [MetadataFilter.decodeHtmlEntities, MetadataFilter.trim]
+});
 
 Connector.getArtist = function () {
-	return decodeHtmlEntity(trackInfo[INFO_ARTIST]);
+	return trackInfo[INFO_ARTIST];
 };
 
 Connector.getTrack = function () {
-	return decodeHtmlEntity(trackInfo[INFO_TRACK]);
+	return trackInfo[INFO_TRACK];
 };
 
 Connector.getCurrentTime = function () {

--- a/connectors/v2/youtube.js
+++ b/connectors/v2/youtube.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global Connector */
+/* global Connector, YoutubeFilter */
 
 var scrobbleMusicOnly = false;
 chrome.storage.local.get('Connectors', function(data) {
@@ -63,7 +63,7 @@ Connector.isStateChangeAllowed = function() {
 };
 
 Connector.getArtistTrack = function () {
-	var text = $.trim($(Connector.artistTrackSelector).text());
+	var text =$(Connector.artistTrackSelector).text();
 
 	text = text.replace(/^\[[^\]]+\]\s*-*\s*/i, ''); // remove [genre] from the beginning of the title
 
@@ -76,41 +76,10 @@ Connector.getArtistTrack = function () {
 	var artist =  text.substr(0, separator.index);
 	var track = text.substr(separator.index + separator.length);
 
-	/**
-	* Clean non-informative garbage from title
-	*/
-
-	// Do some cleanup
-	artist = artist.replace(/^\s+|\s+$/g,'');
-	track = track.replace(/^\s+|\s+$/g,'');
-
-	// Strip crap
-	track = track.replace(/\s*\*+\s?\S+\s?\*+$/, ''); // **NEW**
-	track = track.replace(/\s*\[[^\]]+\]$/, ''); // [whatever]
-	track = track.replace(/\s*\([^\)]*version\)$/i, ''); // (whatever version)
-	track = track.replace(/\s*\.(avi|wmv|mpg|mpeg|flv)$/i, ''); // video extensions
-	track = track.replace(/\s*(LYRIC VIDEO\s*)?(lyric video\s*)/i, ''); // (LYRIC VIDEO)
-	track = track.replace(/\s*(Official Track Stream*)/i, ''); // (Official Track Stream)
-	track = track.replace(/\s*(of+icial\s*)?(music\s*)?video/i, ''); // (official)? (music)? video
-	track = track.replace(/\s*(of+icial\s*)?(music\s*)?audio/i, ''); // (official)? (music)? audio
-	track = track.replace(/\s*(ALBUM TRACK\s*)?(album track\s*)/i, ''); // (ALBUM TRACK)
-	track = track.replace(/\s*(COVER ART\s*)?(Cover Art\s*)/i, ''); // (Cover Art)
-	track = track.replace(/\s*\(\s*of+icial\s*\)/i, ''); // (official)
-	track = track.replace(/\s*\(\s*[0-9]{4}\s*\)/i, ''); // (1999)
-	track = track.replace(/\s+\(\s*(HD|HQ)\s*\)$/, ''); // HD (HQ)
-	track = track.replace(/\s+(HD|HQ)\s*$/, ''); // HD (HQ)
-	track = track.replace(/\s*video\s*clip/i, ''); // video clip
-	track = track.replace(/\s*full\s*album/i, ''); // Full Album
-	track = track.replace(/\s+\(?live\)?$/i, ''); // live
-	track = track.replace(/\(+\s*\)+/, ''); // Leftovers after e.g. (official video)
-	track = track.replace(/^(|.*\s)"(.*)"(\s.*|)$/, '$2'); // Artist - The new "Track title" featuring someone
-	track = track.replace(/^(|.*\s)'(.*)'(\s.*|)$/, '$2'); // 'Track title'
-	track = track.replace(/^[\/\s,:;~-\s"]+/, ''); // trim starting white chars and dash
-	track = track.replace(/[\/\s,:;~-\s"\s!]+$/, ''); // trim trailing white chars and dash
-	//" and ! added because some track names end as {"Some Track" Official Music Video!} and it becomes {"Some Track"!} example: http://www.youtube.com/watch?v=xj_mHi7zeRQ
-
 	return {artist: artist, track: track};
 };
+
+Connector.filter = YoutubeFilter;
 
 /**
  * YouTube doesn't really unload the player. It simply moves it outside viewport.

--- a/connectors/v2/zen-audio-player.js
+++ b/connectors/v2/zen-audio-player.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global Connector */
+/* global Connector, YoutubeFilter */
 
 
 Connector.playerSelector = '#audioplayer';
@@ -20,9 +20,8 @@ Connector.isPlaying = function() {
 	return $('.plyr').hasClass('plyr--playing');
 };
 
-// This code is pulled directly from the YouTube v2 connector
 Connector.getArtistTrack = function () {
-	var text = $.trim($(Connector.artistTrackSelector).text());
+	var text = $(Connector.artistTrackSelector).text();
 
 	var separator = Connector.findSeparator(text);
 
@@ -33,37 +32,7 @@ Connector.getArtistTrack = function () {
 	var artist =  text.substr(0, separator.index);
 	var track = text.substr(separator.index + separator.length);
 
-	/**
-	* Clean non-informative garbage from title
-	*/
-
-	// Do some cleanup
-	artist = artist.replace(/^\s+|\s+$/g,'');
-	track = track.replace(/^\s+|\s+$/g,'');
-
-	// Strip crap
-	track = track.replace(/\s*\*+\s?\S+\s?\*+$/, ''); // **NEW**
-	track = track.replace(/\s*\[[^\]]+\]$/, ''); // [whatever]
-	track = track.replace(/\s*\([^\)]*version\)$/i, ''); // (whatever version)
-	track = track.replace(/\s*\.(avi|wmv|mpg|mpeg|flv)$/i, ''); // video extensions
-	track = track.replace(/\s*(LYRIC VIDEO\s*)?(lyric video\s*)/i, ''); // (LYRIC VIDEO)
-	track = track.replace(/\s*(Official Track Stream*)/i, ''); // (Official Track Stream)
-	track = track.replace(/\s*(of+icial\s*)?(music\s*)?video/i, ''); // (official)? (music)? video
-	track = track.replace(/\s*(of+icial\s*)?(music\s*)?audio/i, ''); // (official)? (music)? audio
-	track = track.replace(/\s*(ALBUM TRACK\s*)?(album track\s*)/i, ''); // (ALBUM TRACK)
-	track = track.replace(/\s*(COVER ART\s*)?(Cover Art\s*)/i, ''); // (Cover Art)
-	track = track.replace(/\s*\(\s*of+icial\s*\)/i, ''); // (official)
-	track = track.replace(/\s*\(\s*[0-9]{4}\s*\)/i, ''); // (1999)
-	track = track.replace(/\s+\(\s*(HD|HQ)\s*\)$/, ''); // HD (HQ)
-	track = track.replace(/\s+(HD|HQ)\s*$/, ''); // HD (HQ)
-	track = track.replace(/\s*video\s*clip/i, ''); // video clip
-	track = track.replace(/\s+\(?live\)?$/i, ''); // live
-	track = track.replace(/\(+\s*\)+/, ''); // Leftovers after e.g. (official video)
-	track = track.replace(/^(|.*\s)"(.*)"(\s.*|)$/, '$2'); // Artist - The new "Track title" featuring someone
-	track = track.replace(/^(|.*\s)'(.*)'(\s.*|)$/, '$2'); // 'Track title'
-	track = track.replace(/^[\/\s,:;~-\s"]+/, ''); // trim starting white chars and dash
-	track = track.replace(/[\/\s,:;~-\s"\s!]+$/, ''); // trim trailing white chars and dash
-	//" and ! added because some track names end as {"Some Track" Official Music Video!} and it becomes {"Some Track"!} example: http://www.youtube.com/watch?v=xj_mHi7zeRQ
-
 	return {artist: artist, track: track};
 };
+
+Connector.filter = YoutubeFilter;

--- a/core/background/inject.js
+++ b/core/background/inject.js
@@ -84,6 +84,7 @@ define([
 				// for v2 connectors prepend BaseConnector, newer jQuery (!) and append starter
 				if (typeof(connector.version) !== 'undefined' && connector.version === 2) {
 					scripts.unshift('core/content/connector.js');
+					scripts.unshift('core/content/filter.js');
 					scripts.unshift('core/content/reactor.js');
 					scripts.unshift('vendor/underscore-min.js');
 					scripts.unshift(config.JQUERY_PATH);

--- a/core/content/connector.js
+++ b/core/content/connector.js
@@ -1,5 +1,5 @@
 'use strict';
-/* globals _ */
+/* globals _, TrimFilter */
 /* exported Connector */
 
 /**
@@ -240,6 +240,14 @@ var BaseConnector = window.BaseConnector || function () {
 			return true;
 		};
 
+		/**
+		 * Filter object used to filter song metadata.
+		 *
+		 * @see {link MetadataFilter}
+		 * @type {MetadataFilter}
+		 */
+		this.filter = TrimFilter;
+
 		// --- state & api -------------------------------------------------------------------------------------------------
 
 
@@ -289,17 +297,20 @@ var BaseConnector = window.BaseConnector || function () {
 				newTrack = artistTrack.track;
 			}
 
+			newTrack = this.filter.filterTrack(newTrack);
 			if (newTrack !== currentState.track) {
 				currentState.track = newTrack;
 				changedFields.push('track');
 			}
 
+			newArtist = this.filter.filterArtist(newArtist);
 			if (newArtist !== currentState.artist) {
 				currentState.artist = newArtist;
 				changedFields.push('artist');
 			}
 
 			var newAlbum = this.getAlbum() || null;
+			newAlbum = this.filter.filterAlbum(newAlbum);
 			if (newAlbum !== currentState.album) {
 				currentState.album = newAlbum;
 				changedFields.push('album');

--- a/core/content/filter.js
+++ b/core/content/filter.js
@@ -1,0 +1,202 @@
+'use strict';
+
+/* exported MetadataFilter, TrimFilter, YoutubeFilter */
+/* jshint node: true */
+
+/**
+ * Export MetadataFilter constructor if script is run in Node.js context.
+ */
+if (typeof module !== 'undefined') {
+	module.exports = {
+		MetadataFilter: MetadataFilter,
+	};
+}
+
+/**
+ * Base filter object that filters metadata fields by given filter set.
+ * A filter set is an object containing 'artist', 'track', 'album' or 'all'
+ * properties. Each property can be defined either as a filter function or as
+ * an array of filter functions. The 'artist', 'track' and 'album' properties
+ * are used to define functions to filter artist, track and album metadata
+ * fields respectively. The 'all' property can be used to define common filter
+ * functions for all metadata fields.
+ *
+ * @constructor
+ * @param {Object} filterSet Set of filters
+ */
+function MetadataFilter(filterSet) {
+	const mergedFilterSet = createMergedFilters(filterSet);
+
+	/**
+	 * Filter text using filters for artist metadata field.
+	 * @param  {String} text String to be filtered
+	 * @return {String} Filtered string
+	 */
+	this.filterArtist = function(text) {
+		return filterField(text, mergedFilterSet.artist);
+	};
+
+	/**
+	 * Filter text using filters for track metadata field.
+	 * @param  {String} text String to be filtered
+	 * @return {String} Filtered string
+	 */
+	this.filterTrack = function(text) {
+		return filterField(text, mergedFilterSet.track);
+	};
+
+	/**
+	 * Filter text using filters for album metadata field.
+	 * @param  {String} text String to be filtered
+	 * @return {String} Filtered string
+	 */
+	this.filterAlbum = function(text) {
+		return filterField(text, mergedFilterSet.album);
+	};
+
+	/**
+	 * Filter text using given filters.
+	 * @param  {String} text String to be filtered
+	 * @param  {Array} filters Array of filter functions
+	 * @return {String} Filtered string
+	 */
+	function filterField(text, filters) {
+		if (text === null || text === '') {
+			return text;
+		}
+
+		filters.forEach(filter => {
+			text = filter(text);
+		});
+
+		return text;
+	}
+
+	function createFilters(filters) {
+		if (typeof filters === 'function') {
+			let filterFunction = filters;
+			return [filterFunction];
+		} else if (Object.prototype.toString.call(filters) === '[object Array]') {
+			return filters;
+		} else {
+			return [];
+		}
+	}
+
+	function createMergedFilters(filterSet) {
+		let mergedFilterSet = {};
+		for (let field of ['artist', 'track', 'album']) {
+			mergedFilterSet[field] = createFilters(filterSet[field])
+				.concat(createFilters(filterSet.all));
+		}
+		return mergedFilterSet;
+	}
+}
+
+/* Predefined filter functions.
+ *
+ * Filter function is a function which takes non-null string argument
+ * and returns modified string.
+ */
+
+/**
+ * Trim given string.
+ * @param  {String} text String to be trimmed
+ * @return {String}	Trimmed string
+ */
+MetadataFilter.trim = function(text) {
+	return text.trim();
+};
+
+/**
+ * Remove zero-width characters from given string.
+ * @param  {String} text String to be filtered
+ * @return {String} Filtered string
+ */
+MetadataFilter.removeZeroWidth = function(text) {
+	return text.replace(/[\u200B-\u200D\uFEFF]/g, '');
+};
+
+/**
+ * Decodes HTML entities in given text string.
+ * @param  {String} text String with HTML entities
+ * @return {String} Decoded string
+ */
+MetadataFilter.decodeHtmlEntities = function(text) {
+	return text.replace(/&#(\d+);/g, (match, dec) => {
+		return String.fromCharCode(dec);
+	});
+};
+
+/**
+ * Remove Youtube-related garbage from the text.
+ * @param  {String} text String to be filtered
+ * @return {String} Filtered string
+ */
+MetadataFilter.youtube = function(text) {
+	let filters = MetadataFilter.YoutubeTrackFilters;
+	for (let source in filters) {
+		let target = filters[source];
+
+		let regexParts = source.match(new RegExp('^/(.*?)/([img]*)$'));
+		if (!regexParts) {
+			console.log('Invalid Youtube filter: ' + source);
+			continue;
+		}
+
+		let regex = new RegExp(regexParts[1], regexParts[2]);
+		text = text.replace(regex, target);
+	}
+
+	return text;
+};
+
+/**
+ * Predefined regex-based filter set for Youtube-based connectors.
+ * The filter set is an object that maps regular expressions to strings
+ * that will be used as replacement.
+ */
+MetadataFilter.YoutubeTrackFilters = {
+	'/^\\s+|\\s+$/g': '', // Trim whitespaces
+	'/\\s*\\*+\\s?\\S+\\s?\\*+$/': '', // **NEW**
+	'/\\s*\\[[^\\]]+\\]$/': '', // [whatever]
+	'/\\s*\\([^\\)]*version\\)$/i': '', // (whatever version)
+	'/\\s*\\.(avi|wmv|mpg|mpeg|flv)$/i': '', // video extensions
+	'/\\s*(LYRIC VIDEO\\s*)?(lyric video\\s*)/i': '', // (LYRIC VIDEO)
+	'/\\s*(Official Track Stream*)/i': '', // (Official Track Stream)
+	'/\\s*(of+icial\\s*)?(music\\s*)?video/i': '', // (official)? (music)? video
+	'/\\s*(of+icial\\s*)?(music\\s*)?audio/i': '', // (official)? (music)? audio
+	'/\\s*(ALBUM TRACK\\s*)?(album track\\s*)/i': '', // (ALBUM TRACK)
+	'/\\s*(COVER ART\\s*)?(Cover Art\\s*)/i': '', // (Cover Art)
+	'/\\s*\\(\\s*of+icial\\s*\\)/i': '', // (official)
+	'/\\s*\\(\\s*[0-9]{4}\\s*\\)/i': '', // (1999)
+	'/\\s+\\(\\s*(HD|HQ)\\s*\\)$/': '', // HD (HQ)
+	'/\\s+(HD|HQ)\\s*$/': '', // HD (HQ)
+	'/\\s*video\\s*clip/i': '', // video clip
+	'/\\s*full\\s*album/i': '', // Full Album
+	'/\\s+\\(?live\\)?$/i': '', // live
+	'/\\(+\\s*\\)+/': '', // Leftovers after e.g. (official video)
+	'/^(|.*\\s)"(.*)"(\\s.*|)$/': '$2', // Artist - The new "Track title" featuring someone
+	'/^(|.*\\s)\'(.*)\'(\\s.*|)$/': '$2', // 'Track title'
+	'/^[\\/\\s,:;~-\\s"]+/': '', // trim starting white chars and dash
+	'/[\\/\\s,:;~-\\s"\\s!]+$/': '', // trim trailing white chars and dash
+};
+
+/**
+ * Simple trim filter object used by default in a Connector object.
+ * @type {MetadataFilter}
+ */
+const TrimFilter = new MetadataFilter({
+	artist: MetadataFilter.trim,
+	track: MetadataFilter.trim,
+	album: MetadataFilter.trim
+});
+
+/**
+ * Predefined filter object for Youtube-based connectors.
+ * @type {MetadataFilter}
+ */
+const YoutubeFilter = new MetadataFilter({
+	track: MetadataFilter.youtube,
+	all: MetadataFilter.trim
+});


### PR DESCRIPTION
Possible solution of #1128.

All description is placed in `core/content/filter.js` module.

Usage examples (it's insanely easy for common cases):
* bandcamp.js, vk.js (common filter with multiple functions);
* bandzone.js (filter using custom filter function);
* youtube.js (Youtube-based filter).

By default, a trim filter is used.

I've checked it on Youtube and some other websites. The filter works fine, so I guess it works fine at all (just because it's a common mechanism for all connectors).

I also merged this branch into `grunt-test` branch and run tests. Didn't find any regressions too.