### PR TITLE
Simplify `getArtistTrack` function usage

### DIFF
--- a/connectors/v2/difm.js
+++ b/connectors/v2/difm.js
@@ -8,15 +8,5 @@ Connector.playButtonSelector = '.ico icon-play';
 
 Connector.getArtistTrack = function() {
 	var text = $('.track-name').attr('title');
-	var separator = this.findSeparator(text);
-
-	var artist = null;
-	var track = null;
-
-	if (separator !== null) {
-		artist = text.substr(0, separator.index);
-		track = text.substr(separator.index + separator.length);
-	}
-
-	return {artist: artist, track: track};
+	return Connector.splitArtistTrack(text);
 };

--- a/connectors/v2/obozrevatel.js
+++ b/connectors/v2/obozrevatel.js
@@ -7,16 +7,7 @@ if ($('.cnt-song-lst').length > 0) {
 
 	Connector.getArtistTrack = function() {
 		var text = $('.playing .song').clone().children('.like-count').remove().end().text();
-		var separator = Connector.findSeparator(text);
-
-		if (separator === null || text.length === 0) {
-			return {artist: null, track: null};
-		}
-
-		var artist =  text.substr(0, separator.index).trim();
-		var track = text.substr(separator.index + separator.length).trim();
-
-		return {artist: artist, track: track};
+		return Connector.splitArtistTrack(text);
 	};
 
 	Connector.isPlaying = function () {
@@ -33,19 +24,7 @@ if ($('.cnt-song-lst').length > 0) {
 } else if ($('.cur-blk').length > 0) {
 	Connector.playerSelector = '.cur-blk';
 
-	Connector.getArtistTrack = function() {
-		var text = $('.cur-blk .name').text();
-		var separator = Connector.findSeparator(text);
-
-		if (separator === null || text.length === 0) {
-			return {artist: null, track: null};
-		}
-
-		var artist =  text.substr(0, separator.index).trim();
-		var track = text.substr(separator.index + separator.length).trim();
-
-		return {artist: artist, track: track};
-	};
+	Connector.artistTrackSelector = '.cur-blk .name';
 
 	Connector.isPlaying = function () {
 		return $('.cur-blk #play').hasClass('pause');

--- a/connectors/v2/plugdj.js
+++ b/connectors/v2/plugdj.js
@@ -35,21 +35,6 @@
 
 Connector.artistTrackSelector = '#now-playing-media .bar-value';
 
-Connector.getArtistTrack = function () {
-	var text = $(Connector.artistTrackSelector).text();
-
-	var separator = Connector.findSeparator(text);
-
-	if (separator === null || text.length === 0) {
-		return {artist: null, track: null};
-	}
-
-	var artist =  text.substr(0, separator.index);
-	var track = text.substr(separator.index + separator.length);
-
-	return {artist: artist, track: track};
-};
-
 Connector.filter = YoutubeFilter;
 
 Connector.isPlaying = function () {

--- a/connectors/v2/redditmusicplayer.js
+++ b/connectors/v2/redditmusicplayer.js
@@ -12,17 +12,7 @@ Connector.getTrackArt = function () {
 
 Connector.getArtistTrack = function () {
 	var text = $('.ui.item.active .title').text().replace(/ \[.*/, '');
-	var separator = this.findSeparator(text);
-
-	var artist = null;
-	var track = null;
-
-	if (separator !== null) {
-		artist = text.substr(0, separator.index);
-		track = text.substr(separator.index + separator.length);
-	}
-
-	return {artist: artist, track: track};
+	return Connector.splitArtistTrack(text);
 };
 
 Connector.isPlaying = function() {

--- a/connectors/v2/redditplayer.js
+++ b/connectors/v2/redditplayer.js
@@ -7,20 +7,7 @@ var INFO_DURATION = 2;
 
 Connector.playerSelector = 'body';
 
-Connector.getArtistTrack = function () {
-	var text = $('#portablecontrols h3').text().replace(' [ buffering... ]', '');
-	var separator = this.findSeparator(text);
-
-	var artist = null;
-	var track = null;
-
-	if (separator !== null) {
-		artist = text.substr(0, separator.index);
-		track = text.substr(separator.index + separator.length);
-	}
-
-	return {artist: artist, track: track};
-};
+Connector.artistTrackSelector = '#portablecontrols h3';
 
 Connector.getCurrentTime = function() {
 	return getTimeInfo(INFO_CURRENT_TIME);

--- a/connectors/v2/solayo.js
+++ b/connectors/v2/solayo.js
@@ -9,22 +9,14 @@ Connector.trackArtImageSelector = '.scImage';
 Connector.artistTrackSelector = '.videoTitle.noColorLink';
 
 Connector.getArtistTrack = function () {
-	if ($(Connector.artistTrackSelector).text().match(/ - /g).length === 2) {
-		var arr = $(Connector.artistTrackSelector).text().split(' - ');
+	var text = $(Connector.artistTrackSelector).text();
+
+	if (text.match(/ - /g).length === 2) {
+		var arr = text.split(' - ');
 		return {artist: arr[1], track: arr[2]};
 	}
-	var text = $(this.artistTrackSelector).text();
-	var separator = this.findSeparator(text);
 
-	var artist = null;
-	var track = null;
-
-	if (separator !== null) {
-		artist = text.substr(0, separator.index);
-		track = text.substr(separator.index + separator.length);
-	}
-
-	return {artist: artist, track: track};
+	return Connector.splitArtistTrack(text);
 };
 
 Connector.isPlaying = function () {

--- a/connectors/v2/sullen-ural.js
+++ b/connectors/v2/sullen-ural.js
@@ -5,20 +5,8 @@
 Connector.playerSelector = '.album-tracks';
 
 Connector.getArtistTrack = function () {
-	var artist = null;
-	var track = null;
-
 	var text = $('.play:contains("ll")').attr('download');
-	if (text) {
-		var separator = this.findSeparator(text);
-
-		if (separator !== null) {
-			artist = text.substr(0, separator.index);
-			track = text.substr(separator.index + separator.length);
-		}
-	}
-
-	return {artist: artist, track: track};
+	return Connector.splitArtistTrack(text);
 };
 
 Connector.isPlaying = function () {

--- a/connectors/v2/wrzuta.pl.js
+++ b/connectors/v2/wrzuta.pl.js
@@ -13,17 +13,7 @@ Connector.isPlaying = function () {
 function setupPlaylistPlayer() {
 	Connector.getArtistTrack = function() {
 		var text = $('.playlist-position.active a.js-file-link').attr('title');
-		var separator = this.findSeparator(text);
-
-		var artist = null;
-		var track = null;
-
-		if (separator !== null) {
-			artist = text.substr(0, separator.index);
-			track = text.substr(separator.index + separator.length);
-		}
-
-		return {artist: artist, track: track};
+		return Connector.splitArtistTrack(text);
 	};
 
 	Connector.getUniqueID = function() {

--- a/connectors/v2/youtube.js
+++ b/connectors/v2/youtube.js
@@ -66,17 +66,7 @@ Connector.getArtistTrack = function () {
 	var text =$(Connector.artistTrackSelector).text();
 
 	text = text.replace(/^\[[^\]]+\]\s*-*\s*/i, ''); // remove [genre] from the beginning of the title
-
-	var separator = Connector.findSeparator(text);
-
-	if (separator === null || text.length === 0) {
-		return {artist: null, track: null};
-	}
-
-	var artist =  text.substr(0, separator.index);
-	var track = text.substr(separator.index + separator.length);
-
-	return {artist: artist, track: track};
+	return Connector.splitArtistTrack(text);
 };
 
 Connector.filter = YoutubeFilter;

--- a/connectors/v2/zen-audio-player.js
+++ b/connectors/v2/zen-audio-player.js
@@ -20,19 +20,4 @@ Connector.isPlaying = function() {
 	return $('.plyr').hasClass('plyr--playing');
 };
 
-Connector.getArtistTrack = function () {
-	var text = $(Connector.artistTrackSelector).text();
-
-	var separator = Connector.findSeparator(text);
-
-	if (separator === null || text.length === 0) {
-		return {artist: null, track: null};
-	}
-
-	var artist =  text.substr(0, separator.index);
-	var track = text.substr(separator.index + separator.length);
-
-	return {artist: artist, track: track};
-};
-
 Connector.filter = YoutubeFilter;

--- a/core/content/connector.js
+++ b/core/content/connector.js
@@ -175,17 +175,7 @@ var BaseConnector = window.BaseConnector || function () {
 		 */
 		this.getArtistTrack = function () {
 			var text = $(this.artistTrackSelector).text();
-			var separator = this.findSeparator(text);
-
-			var artist = null;
-			var track = null;
-
-			if (separator !== null) {
-				artist = text.substr(0, separator.index);
-				track = text.substr(separator.index + separator.length);
-			}
-
-			return {artist: artist, track: track};
+			return this.splitArtistTrack(text);
 		};
 
 		/**
@@ -404,6 +394,27 @@ var BaseConnector = window.BaseConnector || function () {
 			}
 
 			return seconds || 0;
+		};
+
+		/**
+		 * Split string to artist and track.
+		 * @param  {String} str [description]
+		 * @return {Object} Object contains artist and track fields
+		 */
+		this.splitArtistTrack = function(str) {
+			let artist = null;
+			let track = null;
+
+			if (str !== null) {
+				let separator = this.findSeparator(str);
+
+				if (separator !== null) {
+					artist = str.substr(0, separator.index);
+					track = str.substr(separator.index + separator.length);
+				}
+			}
+
+			return {artist, track};
 		};
 
 		/**


### PR DESCRIPTION
Introduce a new function named `splitArtistTrack` which copies the functionality of `getArtistTrack` function but returns an object. Using that function allows to easily override `getArtistTrack` function:
**before**:
```js
Connector.getArtistTrack = function() {
	var text = $('.track-name').attr('title');
	var separator = Connector.findSeparator(text);

	if (separator === null || text.length === 0) {
		return {artist: null, track: null};
	}

	var artist =  text.substr(0, separator.index).trim();
	var track = text.substr(separator.index + separator.length).trim();

	return {artist: artist, track: track};
};
```
**after**:
```js
Connector.getArtistTrack = function() {
	var text = $('.track-name').attr('title');
	return Connector.splitArtistTrack(text);
};
```

I also replaced `getArtistTrack` function by `artistTrackSelector` definition in some connectors.

