### PR TITLE
Fix Youtubify playing state recognition

### DIFF
--- a/connectors/v2/youtubify.js
+++ b/connectors/v2/youtubify.js
@@ -10,8 +10,10 @@ Connector.trackSelector = '.current-track .info .track-name';
 
 Connector.trackArtImageSelector = '.current-track img';
 
-Connector.playButtonSelector = '#player-controls .icon-play';
-
 Connector.durationSelector = '.track-length';
 
 Connector.currentTimeSelector = '.elapsed-time';
+
+Connector.isPlaying = function() {
+	return $('#player-controls .icon-pause').is(':visible');
+};


### PR DESCRIPTION
Youtubify hides play button while loading a song on startup. It makes the connector think the song is playing.