### PR TITLE
Remove unused `Connector.getCurrentTime` function

### DIFF
--- a/connectors/v2/ghostly.js
+++ b/connectors/v2/ghostly.js
@@ -12,10 +12,6 @@ Connector.trackSelector = 'dd.track';
 
 Connector.albumSelector = 'dd.album';
 
-Connector.getCurrentTime = function() {
-	return $('#info_position').text().split('/')[0].trim();
-};
-
 Connector.isPlaying = function() {
 	return $('#play').hasClass('pause');
 };


### PR DESCRIPTION
There's no seekable progress bar on Ghostly website, so this function is completely useless. Moreover, it's broken because it returns string representation of time.