### PR TITLE
amazon connector needs to decode HTML entity references in album title

### DIFF
--- a/connectors/v2/amazon.js
+++ b/connectors/v2/amazon.js
@@ -1,6 +1,10 @@
 'use strict';
 
-/* global Connector */
+/* global Connector, MetadataFilter */
+
+Connector.filter = new MetadataFilter({
+	album: MetadataFilter.decodeHtmlEntities
+});
 
 Connector.playerSelector = '#dragonflyTransport .rightSide';
 

--- a/connectors/v2/amazon.js
+++ b/connectors/v2/amazon.js
@@ -3,7 +3,8 @@
 /* global Connector, MetadataFilter */
 
 Connector.filter = new MetadataFilter({
-	album: MetadataFilter.decodeHtmlEntities
+	album: MetadataFilter.decodeHtmlEntities,
+	all: MetadataFilter.trim
 });
 
 Connector.playerSelector = '#dragonflyTransport .rightSide';


### PR DESCRIPTION
album titles with punctuation or accent are encoded with HTML entity references.
artist names nor track titles are not.
I don't know why, but that's the way it is.