### PR TITLE
Add Emby connector

### DIFF
--- a/connectors/v2/emby.js
+++ b/connectors/v2/emby.js
@@ -9,7 +9,7 @@ Connector.artistSelector = '.nowPlayingBarText .textActionButton[data-type="Musi
 Connector.trackSelector = '.nowPlayingBarText .textActionButton[data-type="MusicAlbum"]';
 
 Connector.isPlaying = function () {
-	return $('.nowPlayingBarCenter .unpauseButton').hasClass('hide');
+	return $('.nowPlayingBarCenter .playPauseButton .md-icon').text() === 'pause';
 };
 
 Connector.getCurrentTime = function () {

--- a/connectors/v2/emby.js
+++ b/connectors/v2/emby.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/* global Connector */
+
+Connector.playerSelector = '.nowPlayingBar';
+
+Connector.artistSelector = '.nowPlayingBarText .textActionButton[data-type="MusicArtist"]';
+
+Connector.trackSelector = '.nowPlayingBarText .textActionButton[data-type="MusicAlbum"]';
+
+Connector.isPlaying = function () {
+	return $('.nowPlayingBarCenter .unpauseButton').hasClass('hide');
+};
+
+Connector.getCurrentTime = function () {
+	var text = $('.nowPlayingBarCenter .nowPlayingBarCurrentTime').text().split('/')[0];
+	return this.stringToSeconds(text);
+};
+
+Connector.getDuration = function () {
+	var text = $('.nowPlayingBarCenter .nowPlayingBarCurrentTime').text().split('/')[1];
+	return this.stringToSeconds(text);
+};
+
+Connector.getTrackArt = function () {
+	// cuts off `url("")` from the background-image property
+	return $('.nowPlayingBarInfoContainer .nowPlayingImage').css('background-image').slice(5,-2);
+};
+
+Connector.getAlbum = function () {
+	return $('.detailSection .parentName:visible').text() ? $('.detailSection .itemName:visible').text() : null;
+};
+
+Connector.getUniqueID = function () {
+	var url = $('.nowPlayingBarInfoContainer .nowPlayingImage').css('background-image');
+	return /Items\/(\w+)/g.exec(url)[1];
+};
+
+Connector.isStateChangeAllowed = function () {
+	// avoids scrobble timer resetting on view change
+	return !this.getCurrentTime()>0
+};

--- a/connectors/v2/emby.js
+++ b/connectors/v2/emby.js
@@ -24,7 +24,7 @@ Connector.getDuration = function () {
 
 Connector.getTrackArt = function () {
 	// cuts off `url("")` from the background-image property
-	return $('.nowPlayingBarInfoContainer .nowPlayingImage').css('background-image').slice(5,-2);
+	return $('.nowPlayingBarInfoContainer .nowPlayingImage').css('background-image').slice(5, -2);
 };
 
 Connector.getAlbum = function () {
@@ -38,5 +38,5 @@ Connector.getUniqueID = function () {
 
 Connector.isStateChangeAllowed = function () {
 	// avoids scrobble timer resetting on view change
-	return !this.getCurrentTime()>0
+	return !this.getCurrentTime() > 0;
 };

--- a/connectors/v2/emby.js
+++ b/connectors/v2/emby.js
@@ -28,7 +28,7 @@ Connector.getTrackArt = function () {
 };
 
 Connector.getAlbum = function () {
-	return $('.detailSection .parentName:visible').text() ? $('.detailSection .itemName:visible').text() : null;
+	return $('.detailSection .parentName:visible').text() === this.getArtist() ? $('.detailSection .itemName:visible').text() : null;
 };
 
 Connector.getUniqueID = function () {

--- a/connectors/v2/emby.js
+++ b/connectors/v2/emby.js
@@ -37,6 +37,6 @@ Connector.getUniqueID = function () {
 };
 
 Connector.isStateChangeAllowed = function () {
-	// avoids scrobble timer resetting on view change
-	return this.getCurrentTime() <= 0;
+	// prevents scrobble timer resetting when user changes view while playing a song
+	return this.getCurrentTime() === 0 || this.getCurrentTime() === this.getDuration();
 };

--- a/connectors/v2/emby.js
+++ b/connectors/v2/emby.js
@@ -38,5 +38,5 @@ Connector.getUniqueID = function () {
 
 Connector.isStateChangeAllowed = function () {
 	// avoids scrobble timer resetting on view change
-	return !this.getCurrentTime() > 0;
+	return this.getCurrentTime() <= 0;
 };

--- a/core/connectors.js
+++ b/core/connectors.js
@@ -1069,5 +1069,12 @@ define(function() {
 			js: ['connectors/v2/mailrumusic.js'],
 			version: 2
 		},
+
+		{
+			label: 'Emby',
+			matches: ['*://*8096/web/*', '*://*8920/web/*', '*://app.emby.media/*'],
+			js: ['connectors/v2/emby.js'],
+			version: 2
+		},
 	];
 });


### PR DESCRIPTION
Added connector for [Emby](https://emby.media/) media server.
Album names are recognized only on album view, because i dont think the necessary info is provided anywhere else.

Tested on Emby v3.1.2.0 and Chrome v55 / Opera v42