### PR TITLE
Adapt to Firefox WebExtensions API

### DIFF
--- a/core/background/main.js
+++ b/core/background/main.js
@@ -71,7 +71,7 @@ require([
 
 			if (!isActiveSession) {
 				isActiveSession = true;
-				GA.send('pageview', '/background-injected?version=' + chrome.app.getDetails().version);
+				GA.send('pageview', '/background-injected?version=' + chrome.runtime.getManifest().version);
 			}
 		}
 	};
@@ -168,7 +168,7 @@ require([
 	function updateVersionInStorage() {
 		let storage = ChromeStorage.getNamespace('Core');
 		storage.get((data) => {
-			data.appVersion = chrome.app.getDetails().version;
+			data.appVersion = chrome.runtime.getManifest().version;
 			storage.set(data);
 		});
 
@@ -183,7 +183,7 @@ require([
 		updateVersionInStorage();
 
 		// track background page loaded - happens once per browser session
-		GA.send('pageview', '/background-loaded?version=' + chrome.app.getDetails().version);
+		GA.send('pageview', '/background-loaded?version=' + chrome.runtime.getManifest().version);
 
 		// check session ID status and show notification if authentication is needed
 		LastFM.getSession(function(sessionID) {

--- a/core/background/notifications.js
+++ b/core/background/notifications.js
@@ -236,6 +236,13 @@ define([
 		removeOnClickedListener(notificationId);
 	});
 
+	// Define getPermissionLevel missing on firefox browser
+	if (chrome.notifications.getPermissionLevel == undefined) { 
+		chrome.notifications.getPermissionLevel = function(notification) {
+				notification("granted");
+			}
+	}
+
 	return {
 		showPlaying: showPlaying,
 		showError: showError,

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,9 @@
     ]
   },
 
-  "options_page": "options/options.html",
+  "options_ui": {
+    "page": "options/options.html"
+  },
 
   "permissions": [
     "tabs",


### PR DESCRIPTION
Made a few adjustements to support Firefox browser.

Just renames except for `chrome.notifications.getPermissionLevel()` which isn't defined there.
I don't know if disabling an extension notification is possible in Firefox so I just stubbed the function.

After this PR we can create an account on addons.mozilla.org and submit the extension for review, see: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Publishing_your_WebExtension
## Test extension in Firefox
* open Firefox
* enter "about:debugging" in the URL bar
* click "Load Temporary Add-on"
* open the add-on's directory and select any file inside the add-on.

Source: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Temporary_Installation_in_Firefox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/david-sabata/web-scrobbler/1247)
<!-- Reviewable:end -->
