### PR TITLE
Play detection to simple language-agnostic selector, times, picture.

### DIFF
--- a/connectors/v2/spotify-open.js
+++ b/connectors/v2/spotify-open.js
@@ -1,14 +1,14 @@
 'use strict';
 
-/* global Connector, Util */
+/* global Connector, MetadataFilter, Util */
 
 /**
  * The connector for new version of Spotify (open.spotify.com).
  */
 
-Connector.playerSelector = '.nowPlayingBar-container';
+Connector.playerSelector = '.now-playing-bar';
 
-Connector.getArtist = function() {
+Connector.getArtist = function () {
 	let artists = $('.track-info__artists a').toArray();
 	return Util.joinArtists(artists);
 };
@@ -22,3 +22,5 @@ Connector.playButtonSelector = '.control-button[class*="spoticon-play-"]';
 Connector.currentTimeSelector = '.player-controls__progress-time:first-child';
 
 Connector.durationSelector = '.player-controls__progress-time:last-child';
+
+Connector.filter = MetadataFilter.getRemasteredFilter();

--- a/connectors/v2/spotify-open.js
+++ b/connectors/v2/spotify-open.js
@@ -6,7 +6,7 @@
  * The connector for new version of Spotify (open.spotify.com).
  */
 
-Connector.playerSelector = '.now-playing-bar';
+Connector.playerSelector = '.nowPlayingBar-container';
 
 Connector.getArtist = function() {
 	let artists = $('.track-info__artists a').toArray();
@@ -17,8 +17,8 @@ Connector.trackSelector = '.track-info__name a';
 
 Connector.trackArtImageSelector = '.now-playing__cover-art .cover-art-image-loaded';
 
-Connector.playButtonSelector = '.control-button[class^="spoticon-pause-"]';
+Connector.playButtonSelector = '.control-button[class*="spoticon-play-"]';
 
-Connector.currentTimeSelector = '.player-controls__progress-bar > div:first-child';
+Connector.currentTimeSelector = '.player-controls__progress-time:first-child';
 
-Connector.durationSelector = '.player-controls__progress-bar > div:last-child';
+Connector.durationSelector = '.player-controls__progress-time:last-child';

--- a/connectors/v2/spotify-open.js
+++ b/connectors/v2/spotify-open.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global Connector, MetadataFilter, Util */
+/* global Connector, Util */
 
 /**
  * The connector for new version of Spotify (open.spotify.com).
@@ -9,16 +9,16 @@
 Connector.playerSelector = '.now-playing-bar';
 
 Connector.getArtist = function() {
-	let artists = $('.now-playing-bar span > span > a').toArray();
+	let artists = $('.track-info__artists a').toArray();
 	return Util.joinArtists(artists);
 };
 
-Connector.trackSelector = '.now-playing-bar div > div > div > a';
+Connector.trackSelector = '.track-info__name a';
 
-Connector.trackArtImageSelector = '.now-playing-bar .cover-art-image-loaded';
+Connector.trackArtImageSelector = '.now-playing__cover-art .cover-art-image-loaded';
 
-Connector.isPlaying = function() {
-	return $('.control-button[title="Pause"]').length > 0;
-};
+Connector.playButtonSelector = '.control-button[class^="spoticon-pause-"]';
 
-Connector.filter = MetadataFilter.getRemasteredFilter();
+Connector.currentTimeSelector = '.player-controls__progress-bar > div:first-child';
+
+Connector.durationSelector = '.player-controls__progress-bar > div:last-child';


### PR DESCRIPTION
Fixes #1270 on My machine™. `open.spotify.com` is now localised so it is not possible to rely on `title` attribute values.