### PR TITLE
Fixing Spotify Open's functionality for retrieving album titles.

### DIFF
--- a/connectors/spotify-open.js
+++ b/connectors/spotify-open.js
@@ -5,6 +5,8 @@
 /**
  * The connector for new version of Spotify (open.spotify.com).
  */
+ 
+var albumTitle;
 
 Connector.playerSelector = '.now-playing-bar';
 
@@ -12,6 +14,20 @@ Connector.getArtist = function () {
 	let artists = $('.track-info__artists a').toArray();
 	return Util.joinArtists(artists);
 };
+
+Connector.getAlbum = function () {
+	if($('.now-playing a')[0].href.indexOf('artist') >= 0 || $('.now-playing a')[0].href.indexOf('playlist') >= 0){
+		$.ajax({ url: $('.now-playing .react-contextmenu-wrapper a')[0].href, success: function(data) { parseAlbumTitle(data); }});
+	}
+	else if($('.now-playing a')[0].href.indexOf('album') >= 0){
+		$.ajax({ url: $('.now-playing a')[0].href, success: function(data) { parseAlbumTitle(data); }});	
+	}
+	return albumTitle;
+}
+
+function parseAlbumTitle(data){
+	albumTitle = ($.parseHTML(data)[3].content);
+}
 
 Connector.trackSelector = '.track-info__name a';
 

--- a/connectors/spotify-open.js
+++ b/connectors/spotify-open.js
@@ -16,7 +16,7 @@ Connector.getArtist = function () {
 };
 
 Connector.getAlbum = function () {
-	if($('.now-playing a')[0].href.indexOf('artist') >= 0 || $('.now-playing a')[0].href.indexOf('playlist') >= 0){
+	if($('.now-playing a')[0].href.indexOf('artist') >= 0 || $('.now-playing a')[0].href.indexOf('playlist') >= 0 || $('.now-playing a')[0].href.indexOf('search') >= 0){
 		$.ajax({ url: $('.now-playing .react-contextmenu-wrapper a')[0].href, success: function(data) { parseAlbumTitle(data); }});
 	}
 	else if($('.now-playing a')[0].href.indexOf('album') >= 0){


### PR DESCRIPTION
Fixing Spotify Open's lack of sending album titles along with scrobbles as per [issue 1320](https://github.com/david-sabata/web-scrobbler/issues/1320) that I opened.

This fix uses a workaround to grab the album title of the currently playing track from an album page, single page, artist page, or playlist via sending an AJAX request to the hidden album url in the new Now Playing section and returning the title from the AJAX request's metadata. It would be more straightforward to use Spotify's API, but they've just turned off all un-authenticated API requests as of 2 days ago. This fix works on all areas of the site and scrobbles properly to Last.FM as well.