### PR TITLE
Separate Hype Machine connectors.

### DIFF
--- a/connectors/hypem-premieres.js
+++ b/connectors/hypem-premieres.js
@@ -1,0 +1,11 @@
+'use strict';
+
+Connector.playerSelector = '.hype-player';
+
+Connector.artistSelector = '#album-header-artist';
+
+Connector.trackSelector = 'li.active .title';
+
+Connector.trackArtSelector = 'img#album-big';
+
+Connector.isPlaying = () => $('.hype-player').hasClass('playing');

--- a/connectors/hypem.js
+++ b/connectors/hypem.js
@@ -1,50 +1,22 @@
 'use strict';
 
-setupConnector();
+Connector.playerSelector = '#player-controls';
 
-function setupConnector() {
-	if (isPremiere()) {
-		setupPremierePlayer();
-	} else {
-		setupDefaultPlayer();
+Connector.artistSelector = '#player-nowplaying [href^="/artist/"]';
+
+Connector.trackSelector = '#player-nowplaying [href^="/track/"]';
+
+Connector.getTrackArt = () => {
+	let styleProperty = $('.thumb').attr('style');
+	return Util.extractUrlFromCssProperty(styleProperty);
+};
+
+Connector.getUniqueID = () => {
+	let trackUrl = $('#player-nowplaying [href^="/track/"]').attr('href');
+	if (trackUrl) {
+		return trackUrl.split('/').pop();
 	}
-}
+	return null;
+};
 
-function isPremiere() {
-	return /^\/premiere\/.*/.test(window.location.pathname);
-}
-
-function setupPremierePlayer() {
-	Connector.playerSelector = '.hype-player';
-
-	Connector.artistSelector = '#album-header-artist';
-
-	Connector.trackSelector = 'li.active .title';
-
-	Connector.trackArtSelector = 'img#album-big';
-
-	Connector.isPlaying = () => $('.hype-player').hasClass('playing');
-}
-
-function setupDefaultPlayer() {
-	Connector.playerSelector = '#player-controls';
-
-	Connector.artistSelector = '#player-nowplaying [href^="/artist/"]';
-
-	Connector.trackSelector = '#player-nowplaying [href^="/track/"]';
-
-	Connector.getTrackArt = () => {
-		let styleProperty = $('.thumb').attr('style');
-		return Util.extractUrlFromCssProperty(styleProperty);
-	};
-
-	Connector.getUniqueID = () => {
-		let trackUrl = $('#player-nowplaying [href^="/track/"]').attr('href');
-		if (trackUrl) {
-			return trackUrl.split('/').pop();
-		}
-		return null;
-	};
-
-	Connector.isPlaying = () => $('#playerPlay').hasClass('pause');
-}
+Connector.isPlaying = () => $('#playerPlay').hasClass('pause');

--- a/core/connectors.js
+++ b/core/connectors.js
@@ -354,6 +354,12 @@ define(function () {
 	},
 
 	{
+		label: 'Hype Machine Premieres',
+		matches: ['*://hypem.com/premiere/*'],
+		js: ['connectors/hypem-premieres.js'],
+	},
+
+	{
 		label: 'Hype Machine',
 		matches: ['*://hypem.com/*'],
 		js: ['connectors/hypem.js'],

--- a/tests/connectors/hypem-premieres.js
+++ b/tests/connectors/hypem-premieres.js
@@ -2,7 +2,7 @@
 
 module.exports = function(driver, connectorSpec) {
 	connectorSpec.shouldBehaveLikeMusicSite(driver, {
-		url: 'http://hypem.com/artist/Violet+Days+x+Win+and+Woo',
-		playButtonSelector: '.tools .playdiv'
+		url: 'http://hypem.com/premiere/the+stevens',
+		playButtonSelector: '.icon-play'
 	});
 };


### PR DESCRIPTION
This allows one to use Hype Machine's built-in scrobbling while still being
able to scrobble premieres.