### PR TITLE
Add a connector for beta TuneIn (@beta.tunein.com)

### DIFF
--- a/connectors/tunein-beta.js
+++ b/connectors/tunein-beta.js
@@ -2,17 +2,9 @@
 
 /* global Connector */
 
-// Full player container (bar at the bottom)	: [data-testid]="player"#player	.player__playerContainer___JEJ2U
-//   'Currently playing' container          	: #nowPlayingContainer         	.player__nowPlayingContainer___2FBjw
-
 Connector.playerSelector = '.player__playerContainer___JEJ2U';
-// Connector.playerSelector = '[data-testid]="player"'; // Alternative with div id. Not working due to data class, div id #player is another element
-
-// Connector.artistTrackSelector = '.nowPlaying__title___2No7P'; //'Artist - Title' format, hence can't use artist/trackSelector
-Connector.artistTrackSelector = '#playerTitle';	// Alternative with div ids instead of classes
-
-// Connector.trackArtSelector = '.nowPlaying__artworkImage___2N-EA';
-Connector.trackArtSelector = '#playerArtwork'; //Alternative with div ids instead of classes
+Connector.artistTrackSelector = '#playerTitle';
+Connector.trackArtSelector = '#playerArtwork';
 
 Connector.isPlaying = function () {
 	return $('#playerActionButton').hasClass('playing');

--- a/connectors/tunein-beta.js
+++ b/connectors/tunein-beta.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/* global Connector */
+
+// Full player container (bar at the bottom)	: [data-testid]="player"#player	.player__playerContainer___JEJ2U
+//   'Currently playing' container          	: #nowPlayingContainer         	.player__nowPlayingContainer___2FBjw
+
+Connector.playerSelector = '.player__playerContainer___JEJ2U';
+// Connector.playerSelector = '[data-testid]="player"'; // Alternative with div id. Not working due to data class, div id #player is another element
+
+// Connector.artistTrackSelector = '.nowPlaying__title___2No7P'; //'Artist - Title' format, hence can't use artist/trackSelector
+Connector.artistTrackSelector = '#playerTitle';	// Alternative with div ids instead of classes
+
+// Connector.trackArtSelector = '.nowPlaying__artworkImage___2N-EA';
+Connector.trackArtSelector = '#playerArtwork'; //Alternative with div ids instead of classes
+
+Connector.isPlaying = function () {
+	return $('#playerActionButton').hasClass('playing');
+};

--- a/core/connectors.js
+++ b/core/connectors.js
@@ -288,6 +288,12 @@ define(function () {
 	},
 
 	{
+		label: 'TuneIn-Beta',
+		matches: ['*://beta.tunein.com/*'],
+		js: ['connectors/tunein-beta.js'],
+	},
+
+	{
 		label: 'MixCloud',
 		matches: ['*://mixcloud.com/*', '*://*.mixcloud.com/*'],
 		js: ['connectors/mixcloud.js'],


### PR DESCRIPTION
Hey, thanks for the great addon! [TuneIn radio](https://beta.tunein.com) changed their interface in the new (beta) version, so the old connector stopped working. I've looked through the code on the new page and made a new connector, which does work with the new version.

I have just one question, though. Given that `div classes` have strange names like '.player__playerContainer___JEJ2U', which I'm not sure will remain unchanged relative to the more generic looking `div ids`, is there a way to refer to th

At the moment this only affects the following piece of code (not sure how important it is) since it has a `data-testid` instead of the regular `div id` (like other items) and I don't know how to write a proper condition referencing such `data` elements.

```
Connector.playerSelector = '.player__playerContainer___JEJ2U';
// Connector.playerSelector = '[data-testid]="player"'; // Alternative with div id. Not working due to data class, div id #player is another element
```