### PR TITLE
Add JetSetRadio.live connector

### DIFF
--- a/connectors/jetsetradio.live.js
+++ b/connectors/jetsetradio.live.js
@@ -2,5 +2,3 @@
 
 Connector.artistTrackSelector = '#programInformationText';
 Connector.playerSelector = '#programInformationText';
-
-Connector.isPlaying = () => true;

--- a/connectors/jetsetradio.live.js
+++ b/connectors/jetsetradio.live.js
@@ -1,0 +1,6 @@
+'use strict';
+
+Connector.artistTrackSelector = '#programInformationText';
+Connector.playerSelector = '#programInformationText';
+
+Connector.isPlaying = () => true;

--- a/core/connectors.js
+++ b/core/connectors.js
@@ -1086,5 +1086,9 @@ define(function() {
 		label: 'Patari',
 		matches: ['*://patari.pk/*'],
 		js: ['connectors/patari.js']
+	}, {
+		label: 'JetSetRadio Live',
+		matches: ['*://jetsetradio.live/*', '*://jetsetradio.live'],
+		js: ['connectors/jetsetradio.live.js']
 	}];
 });


### PR DESCRIPTION
It's a little .. awkward since there's not a player in the strictest sense of the word here, just a next button. I'm relying on the text of the track not changing except between tracks here, which I think is the correct behavior from my watching last.fm. 

I tested this in Firefox