### PR TITLE
Add feature to swap title and artist

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -383,6 +383,22 @@
     "message": "You cannot edit skipped track",
     "description": "Title of edit button"
   },
+  "infoSwap": {
+    "message": "Swap",
+    "description": "Label of swap button"
+  },
+  "infoSwapTitle": {
+    "message": "Swap title and artist",
+    "description": "Title of swap button"
+  },
+  "infoSwapUnableTitle": {
+    "message": "You cannot swap scrobbled track",
+    "description": "Title of swap button"
+  },
+  "infoSwapSkippedTitle": {
+    "message": "You cannot swap skipped track",
+    "description": "Title of swap button"
+  },
   "infoSubmit": {
     "message": "Submit",
     "description": "Label of submit button"

--- a/popups/info.html
+++ b/popups/info.html
@@ -25,6 +25,7 @@
 		</div>
 		<div id="edit-controls">
 			<span id="edit-link" class="control-btn"></span>
+			<span id="swap-link" class="control-btn"></span>
 			<span id="revert-link" class="control-btn"></span>
 			<span id="skip-link" class="control-btn"></span>
 		</div>

--- a/popups/info.js
+++ b/popups/info.js
@@ -176,6 +176,7 @@ $(document).ready(function() {
 		}
 
 		$('#edit-link').off('click');
+		$('#swap-link').off('click');
 		$('#skip-link').off('click');
 
 		if (!song.flags.isSkipped) {
@@ -186,6 +187,9 @@ $(document).ready(function() {
 				} else {
 					setEditMode(true);
 				}
+			});
+			$('#swap-link').on('click', () => {
+				swapTitleAndArtist();
 			});
 			$('#skip-link').on('click', () => {
 				skipSong();
@@ -230,6 +234,11 @@ $(document).ready(function() {
 		$('#edit-link').attr('data-disable', song.flags.isSkipped ||
 			song.flags.isScrobbled);
 
+		$('#swap-link').text(i18n('infoSwap'));
+		$('#swap-link').attr('data-hide', !isEditModeEnabled);
+		$('#swap-link').attr('data-disable', song.flags.isScrobbled ||
+			song.flags.isSkipped);
+
 		$('#revert-link').text(i18n('infoRevert'));
 		$('#revert-link').attr('data-hide', !song.flags.isCorrectedByUser
 			|| isEditModeEnabled);
@@ -243,13 +252,16 @@ $(document).ready(function() {
 
 		if (song.flags.isScrobbled) {
 			$('#edit-link').attr('title', i18n('infoEditUnableTitle'));
+			$('#swap-link').attr('title', i18n('infoSwapUnableTitle'));
 			$('#revert-link').attr('title', i18n('infoRevertUnableTitle'));
 			$('#skip-link').attr('title', i18n('infoSkipUnableTitle'));
 		} else if (song.flags.isSkipped) {
 			$('#edit-link').attr('title', i18n('infoEditSkippedTitle'));
+			$('#swap-link').attr('title', i18n('infoSwapSkippedTitle'));
 			$('#skip-link').attr('title', i18n('infoSkipAlreadyTitle'));
 		} else {
 			$('#edit-link').attr('title', i18n('infoEditTitle'));
+			$('#swap-link').attr('title', i18n('infoSwapTitle'));
 			$('#revert-link').attr('title', i18n('infoRevertTitle'));
 			$('#skip-link').attr('title', i18n('infoSkipTitle'));
 		}
@@ -293,6 +305,22 @@ $(document).ready(function() {
 	function getCoverArt() {
 		return song.parsed.trackArt || song.metadata.artistThumbUrl ||
 			'/icons/default_cover_art.png';
+	}
+
+	function swapTitleAndArtist() {
+		if (song.flags.isSkipped || song.flags.isScrobbled ||
+			!isEditModeEnabled) {
+			return;
+		}
+
+		var title = $('#track-input').val();
+		var artist = $('#artist-input').val();
+
+		$('#track-input').val(artist);
+		$('#artist-input').val(title);
+
+		setEditMode(false);
+		correctSongInfo();
 	}
 
 	function i18n(tag, ...context) {


### PR DESCRIPTION
I mainly use this extension with YouTube, which contains many videos that have their title and artist reverted. This change adds a "Swap" button to the info popup when editing the metadata. The button swaps the title and the artist, then submits the correction.