### PR TITLE
Use data() and val() APIs

### DIFF
--- a/connectors/1ting.js
+++ b/connectors/1ting.js
@@ -21,7 +21,7 @@ function isH5Player() {
 function setupDefaultPlayer() {
 	Connector.playerSelector = '.playact';
 
-	Connector.getUniqueID = () => $('.playing').attr('id').substr(3);
+	Connector.getUniqueID = () => $('.playing input').val();
 
 	Connector.trackSelector = '#songinfo .songtitle>a';
 
@@ -59,7 +59,7 @@ function setupDayPlayer() {
 function setupH5Player() {
 	Connector.playerSelector = '#nowplaying';
 
-	Connector.getUniqueID = () => $('a.current').attr('data-id');
+	Connector.getUniqueID = () => $('a.current').data('id');
 
 	Connector.trackSelector = '#song-name';
 

--- a/connectors/8tracks.js
+++ b/connectors/8tracks.js
@@ -19,7 +19,7 @@ function setupYoutubePlayer() {
 	Connector.isPlaying = () => $('#mix_youtube').hasClass('playing');
 
 	Connector.getUniqueID = () => {
-		return $('.track_details_container a').attr('data-track_id');
+		return $('.track_details_container a').data('track_id');
 	};
 }
 

--- a/connectors/xiami.js
+++ b/connectors/xiami.js
@@ -16,4 +16,4 @@ Connector.trackArtSelector = '#J_playerCoverImg';
 
 Connector.durationSelector = '#J_durationTime';
 
-Connector.getUniqueID = () => $('.ui-track-current .c1').attr('data-id');
+Connector.getUniqueID = () => $('.ui-track-current .c1').data('id');


### PR DESCRIPTION
For di.fm, use the selector instead

---
The `MusicPlayer` setup for [obozrevatel](http://radio.obozrevatel.com/) also uses `attr('data-*')`, but I can't find an instance to test the `data()` API, so it is not included.