### PR TITLE
Updated "fritz" and "radioeins" connectors

### DIFF
--- a/connectors/fritz.js
+++ b/connectors/fritz.js
@@ -6,23 +6,4 @@ Connector.artistSelector = 'div.teasertext > h3 > a > span.manualteasertitle';
 
 Connector.trackSelector = 'div.teasertext > h3 > h3 > span.manualteasertitle';
 
-Connector.isPlaying = () => {
-	let state = retrieveJwplayerState();
-	return (typeof state === 'string') && (state.toUpperCase() === 'PLAYING');
-};
-
-function retrieveJwplayerState() {
-	let scriptContent = 'if (typeof jwplayer === "function") $("body").attr("tmp_state", typeof jwplayer().getState === "function" ? jwplayer().getState() : "");\n';
-
-	let script = document.createElement('script');
-	script.id = 'tmpScript';
-	script.appendChild(document.createTextNode(scriptContent));
-	(document.body || document.head || document.documentElement).appendChild(script);
-
-	let ret = $('body').attr('tmp_state');
-
-	$('body').removeAttr('tmp_state');
-	$('#tmpScript').remove();
-
-	return ret;
-}
+Connector.isPlaying = () => $('.player').hasClass('player_playing');

--- a/connectors/radioeins.js
+++ b/connectors/radioeins.js
@@ -7,8 +7,14 @@ Connector.artistSelector = 'p.artist';
 Connector.trackSelector = 'p.songtitle';
 
 Connector.isPlaying = () => {
-	let state = retrieveJwplayerState();
-	return (typeof state === 'string') && (state.toUpperCase() === 'PLAYING');
+	let ret = false;
+	if ($('#lsplayer audio') && $('#lsplayer audio').length) {
+		ret = !$('#lsplayer audio')[0].paused;
+	} else {
+		let state = retrieveJwplayerState();
+		ret = (typeof state === 'string') && (state.toUpperCase() === 'PLAYING');
+	}
+	return ret;
 };
 
 function retrieveJwplayerState() {


### PR DESCRIPTION
### Simplified "fritz" connector

The "is playing" status can simply be determined from a certain tag's class names.

### Two types of "radioeins" players exist

The player page randomly provides one player (jwplayer) or another (lsplayer). The old (rather complicated) player is still supported. The new player has an element.