### PR TITLE
Xiami: Delay getDuration() till playing starts

### DIFF
--- a/connectors/xiami.js
+++ b/connectors/xiami.js
@@ -14,6 +14,9 @@ Connector.currentTimeSelector = '#J_positionTime';
 
 Connector.trackArtSelector = '#J_playerCoverImg';
 
-Connector.durationSelector = '#J_durationTime';
+Connector.getDuration = () => {
+	let text = Connector.getCurrentTime() ? $('#J_durationTime').text() : '';
+	return Util.stringToSeconds(text);
+};
 
 Connector.getUniqueID = () => $('.ui-track-current .c1').data('id');


### PR DESCRIPTION
To avoid triggering multiple state changed events during loading
(the shown duration changes in this period)