### PR TITLE
Add Youtube “Topic” Support

### DIFF
--- a/connectors/youtube.js
+++ b/connectors/youtube.js
@@ -75,16 +75,16 @@ function isViewTubeInstalled() {
 
 /**
  * Parse webpage and return track Artist and Title
- * @returns {ArtistTrack} The track's Artist and Title
+ * @return {ArtistTrack} The track's Artist and Title
  */
 function getArtistTrack() {
-	let videoTitle = $('.ytp-title-link').text(),
-		byLineMatch = $('#owner-name a').text().match(/(.+) - Topic/);
+	let videoTitle = $('.ytp-title-link').text();
+	let	byLineMatch = $('#owner-name a').text().match(/(.+) - Topic/);
 	if (byLineMatch) {
 		return { artist: byLineMatch[1], track: videoTitle };
 	}
 	return Util.processYoutubeVideoTitle(videoTitle);
-};
+}
 
 /**
  * Setup default Youtube player.

--- a/connectors/youtube.js
+++ b/connectors/youtube.js
@@ -68,12 +68,30 @@ function isViewTubeInstalled() {
 }
 
 /**
+ * @typedef {Object} ArtistTrack
+ * @property {string} artist The track's artist
+ * @property {string} track The track's title
+ */
+
+/**
+ * Parse webpage and return track Artist and Title
+ * @returns {ArtistTrack} The track's Artist and Title
+ */
+function getArtistTrack() {
+	let videoTitle = $('.ytp-title-link').text(),
+		byLineMatch = $('#owner-name a').text().match(/(.+) - Topic/);
+	if (byLineMatch) {
+		return { artist: byLineMatch[1], track: videoTitle };
+	}
+	return Util.processYoutubeVideoTitle(videoTitle);
+};
+
+/**
  * Setup default Youtube player.
  */
 function setupDefaultPlayer() {
 	Connector.getArtistTrack = () => {
-		let videoTitle = $('.ytp-title-link').text();
-		return Util.processYoutubeVideoTitle(videoTitle);
+		return getArtistTrack();
 	};
 
 	/**
@@ -143,8 +161,7 @@ function setupMaterialPlayer() {
 			return Util.makeEmptyArtistTrack();
 		}
 
-		let videoTitle = $('.ytp-title-link').text();
-		return Util.processYoutubeVideoTitle(videoTitle);
+		return getArtistTrack();
 	};
 
 	/**

--- a/connectors/youtube.js
+++ b/connectors/youtube.js
@@ -79,7 +79,7 @@ function isViewTubeInstalled() {
  */
 function getArtistTrack() {
 	let videoTitle = $('.ytp-title-link').text();
-	let byLineMatch = $('#owner-name a').text().match(/(.+) - Topic/);
+	let byLineMatch = $('#meta-contents #owner-name a').text().match(/(.+) - Topic/);
 	if (byLineMatch) {
 		return { artist: byLineMatch[1], track: videoTitle };
 	}

--- a/connectors/youtube.js
+++ b/connectors/youtube.js
@@ -79,7 +79,7 @@ function isViewTubeInstalled() {
  */
 function getArtistTrack() {
 	let videoTitle = $('.ytp-title-link').text();
-	let	byLineMatch = $('#owner-name a').text().match(/(.+) - Topic/);
+	let byLineMatch = $('#owner-name a').text().match(/(.+) - Topic/);
 	if (byLineMatch) {
 		return { artist: byLineMatch[1], track: videoTitle };
 	}


### PR DESCRIPTION
Youtube makes music from record companies available in channels where the channel name is in the form “{Artist} - Topic”. In these videos, the song title is the entire video title.  
In the previous pull request, it was asked if this is an edge case. The answer is no. Youtube has an extensive library of music provided by record companies.  
An example is the channel "The Who - Topic"   
https://www.youtube.com/channel/UCpxn_sVrLQWNGFK1eulpYgw   
You can also search an artist and a lot, though not all, will have a “Topic” channel.  
https://www.youtube.com/channel/UCUlTyoiUjykZj7ZReC0bF0g  
https://www.youtube.com/channel/UC3JOXRxyRQplPWEWy-2JhKQ  
https://www.youtube.com/channel/UCr5cSvqvwamW-fUnVTa9nlw  
https://www.youtube.com/channel/UCNAbUat5xDtp6FeBphe2V_Q  
https://www.youtube.com/channel/UCedvOgsKFzcK3hA5taf3KoQ  

These changes check the channel name to see if it ends with “- Topic” and if so, extracts the artist name from the channel name and uses the video title as the track title.

ref #1067